### PR TITLE
Fix multistage economizer coil validation

### DIFF
--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -830,6 +830,7 @@ void SimOAController(EnergyPlusData &state, std::string const &CtrlName, int &Ct
                             "following types: Coil:Cooling:DX:MultiSpeed,"
                             " Coil:Cooling:DX:VariableSpeed, or Coil:Cooling:DX. EconomizerFirst will not be enforced.",
                             state.dataMixedAir->OAController(OAControllerNum).Name));
+                    state.dataMixedAir->OAController(OAControllerNum).EconomizerStagingType = HVAC::EconomizerStagingType::InterlockedWithMechanicalCooling;
                 }
             }
             primaryAirSystems.EconomizerStagingCheckFlag = true;

--- a/src/EnergyPlus/MixedAir.cc
+++ b/src/EnergyPlus/MixedAir.cc
@@ -830,7 +830,8 @@ void SimOAController(EnergyPlusData &state, std::string const &CtrlName, int &Ct
                             "following types: Coil:Cooling:DX:MultiSpeed,"
                             " Coil:Cooling:DX:VariableSpeed, or Coil:Cooling:DX. EconomizerFirst will not be enforced.",
                             state.dataMixedAir->OAController(OAControllerNum).Name));
-                    state.dataMixedAir->OAController(OAControllerNum).EconomizerStagingType = HVAC::EconomizerStagingType::InterlockedWithMechanicalCooling;
+                    state.dataMixedAir->OAController(OAControllerNum).EconomizerStagingType =
+                        HVAC::EconomizerStagingType::InterlockedWithMechanicalCooling;
                 }
             }
             primaryAirSystems.EconomizerStagingCheckFlag = true;

--- a/tst/EnergyPlus/unit/MixedAir.unit.cc
+++ b/tst/EnergyPlus/unit/MixedAir.unit.cc
@@ -74,8 +74,10 @@
 #include <EnergyPlus/OutAirNodeManager.hh>
 #include <EnergyPlus/Psychrometrics.hh>
 #include <EnergyPlus/ScheduleManager.hh>
+#include <EnergyPlus/SimAirServingZones.hh>
 #include <EnergyPlus/SingleDuct.hh>
 #include <EnergyPlus/SizingManager.hh>
+#include <EnergyPlus/UnitarySystem.hh>
 #include <EnergyPlus/ZoneAirLoopEquipmentManager.hh>
 #include <EnergyPlus/ZoneEquipmentManager.hh>
 
@@ -8054,6 +8056,59 @@ TEST_F(EnergyPlusFixture, MixedAir_TemperatureError)
 
     // T_db must be >= T_sat at the mixed-air node to remain physical
     EXPECT_TRUE(state->dataMixedAir->OAMixer(1).MixTemp >= T_sat);
+}
+
+TEST_F(EnergyPlusFixture, MixedAir_EconomizerFirstValidationWarning)
+{
+    state->dataMixedAir->GetOAControllerInputFlag = false;
+    state->dataGlobal->SysSizingCalc = true;
+
+    state->dataMixedAir->NumOAControllers = 1;
+    state->dataMixedAir->OAController.allocate(1);
+    auto &oaCtrl = state->dataMixedAir->OAController(1);
+    oaCtrl.Name = "OA CTRL 1";
+    oaCtrl.EconomizerStagingType = HVAC::EconomizerStagingType::EconomizerFirst;
+
+    state->dataAirSystemsData->PrimaryAirSystems.allocate(1);
+    auto &airSys = state->dataAirSystemsData->PrimaryAirSystems(1);
+    airSys.NumBranches = 1;
+    airSys.Branch.allocate(1);
+    airSys.Branch(1).TotalComponents = 1;
+    airSys.Branch(1).Comp.allocate(1);
+    airSys.Branch(1).Comp(1).CompType_Num = SimAirServingZones::CompType::UnitarySystemModel;
+    airSys.Branch(1).Comp(1).Name = "UNITARY SYS 1";
+
+    state->dataUnitarySystems->numUnitarySystems = 1;
+    state->dataUnitarySystems->unitarySys.resize(1);
+    state->dataUnitarySystems->unitarySys[0].Name = "UNITARY SYS 1";
+    state->dataUnitarySystems->unitarySys[0].m_ControlType = UnitarySystems::UnitarySys::UnitarySysCtrlType::Load;
+    state->dataUnitarySystems->unitarySys[0].m_coolCoilType = HVAC::CoilType::CoolingDXTwoSpeed;
+
+    state->dataLoopNodes->Node.allocate(3);
+    oaCtrl.OANode = 1;
+    oaCtrl.InletNode = 1;
+    oaCtrl.RetNode = 2;
+    oaCtrl.RelNode = 2;
+    oaCtrl.MixNode = 3;
+    state->dataLoopNodes->Node(3).MassFlowRateMaxAvail = 0.0;
+    state->dataAirLoop->AirLoopControlInfo.emplace_back();
+    state->dataAirLoop->AirLoopFlow.emplace_back();
+
+    state->dataMixedAir->InitOAControllerOneTimeFlag = false;
+    state->dataMixedAir->OAControllerMyOneTimeFlag.dimension(1, false);
+    state->dataMixedAir->OAControllerMyEnvrnFlag.dimension(1, false);
+    state->dataMixedAir->OAControllerMySizeFlag.dimension(1, false);
+    state->dataMixedAir->MechVentCheckFlag.dimension(1, false);
+    state->dataMixedAir->InitOAControllerSetPointCheckFlag.dimension(1, false);
+
+    EXPECT_FALSE(airSys.EconomizerStagingCheckFlag);
+
+    int ctrlIndex = 1;
+    MixedAir::SimOAController(*state, "OA CTRL 1", ctrlIndex, false, 1);
+
+    EXPECT_TRUE(airSys.EconomizerStagingCheckFlag);
+    EXPECT_EQ(oaCtrl.EconomizerStagingType, HVAC::EconomizerStagingType::InterlockedWithMechanicalCooling);
+    EXPECT_TRUE(match_err_stream("EconomizerFirst will not be enforced"));
 }
 
 } // namespace EnergyPlus


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11725 

### Description of the purpose of this PR

The proposed changes fix the validation for the multistage economizer feature which was developed and tested around  the `Coil:Cooling:DX`, `Coil:Cooling:DX:MultiSpeed`, and `Coil:Cooling:DX:VariableSpeed` objects (see [here](https://github.com/NatLabRockies/EnergyPlus/blob/develop/design/FY2023/NFP-MultistageEconomizer.md) and [here](https://github.com/NatLabRockies/EnergyPlus/pull/9987)).

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [x] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [x] If changes fix a defect, the fix should be demonstrated in plots and descriptions

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
