### PR TITLE
Fix #9773 - Translate \type node from IDD into Energy+.schema.epJSON

### DIFF
--- a/idd/schema/idd_parser.py
+++ b/idd/schema/idd_parser.py
@@ -535,6 +535,10 @@ def parse_field(data, token):
                     root["type"] = "integer"
             elif match_string(data, NODE_STR):
                 root["type"] = "string"
+                if "data_type" not in root:
+                    root["data_type"] = "node"
+                else:
+                    raise RuntimeError(r"two \type node?")
             else:
                 bad_type = parse_line(data)
                 raise RuntimeError('Invalid \\type: "%s"' % bad_type)

--- a/idd/schema/test_idd_parser.py
+++ b/idd/schema/test_idd_parser.py
@@ -240,7 +240,7 @@ MyObject,
         "patternProperties": {
             ".*": {
                 "type": "object",
-                "properties": {"inlet_node_name": {"type": "string"}},
+                "properties": {"inlet_node_name": {"type": "string", "data_type": "node"}},
                 "required": [
                     "inlet_node_name",
                 ],

--- a/idd/schema/test_idd_parser.py
+++ b/idd/schema/test_idd_parser.py
@@ -222,3 +222,38 @@ BrokenObject,
   N1; \field Number 1
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
     )
+
+
+def test_idd_type_node():
+    data = idd_parser.Data()
+    data.file = r"""
+\group test
+
+MyObject,
+  A1; \field Inlet Node Name
+      \type node
+      \required-field
+"""
+    idd_parser.parse_idd(data)
+    assert data.schema["properties"].keys() == {"MyObject"}
+    assert data.schema["properties"]["MyObject"] == {
+        "patternProperties": {
+            ".*": {
+                "type": "object",
+                "properties": {"inlet_node_name": {"type": "string"}},
+                "required": [
+                    "inlet_node_name",
+                ],
+            }
+        },
+        "group": "test",
+        "legacy_idd": {
+            "field_info": {
+                "inlet_node_name": {"field_name": "Inlet Node Name", "field_type": "a"},
+            },
+            "fields": ["inlet_node_name"],
+            "alphas": {"fields": ["inlet_node_name"]},
+            "numerics": {"fields": []},
+        },
+        "type": "object",
+    }


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #9773

<!-- NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE -->

### Description of the purpose of this PR

**Add data_type = node for node objects**

Just like `object-list` and `external-list` types, we keep `root["type"] = "string"` for node, and add `root["data_type"] = "node"` alongside it.

The reason we can't set `type = "node"` is that EnergyPlus validates epJSON input using valijson, https://github.com/NatLabRockies/EnergyPlus/blob/1d8feb797c2e3407a8f272bb4c5a803ae40c3fb1/src/EnergyPlus/InputProcessing/InputValidation.cc#L89-L95

which parses `Energy+.schema.epJSON` as a real JSON-Schema document via `valijson::SchemaParser::populateSchema`. Its only recognizes the standard JSON Schema type names (string, number, integer, boolean, object, array, null, any) — anything else throws.

https://github.com/NatLabRockies/EnergyPlus/blob/1d8feb797c2e3407a8f272bb4c5a803ae40c3fb1/third_party/valijson/valijson/constraints/concrete_constraints.hpp#L1222-L1247

So setting `root["type"] = "node"` in idd_parser.py would make valijson throw/abort while parsing the schema itself — not a validation failure on one field, but a crash before any epJSON file can be validated at all.

Having this new attribute is enough for third party consumers (like epJSON editor) to understand the field is supposed to be a node.


The epJSON has lots of the same diff

```diff
                     "type": "object",
                     "properties": {
                         "inlet_node_name": {
-                            "type": "string"
+                            "type": "string",
+                            "data_type": "node"
                         },
                         "outlet_node_name": {
-                            "type": "string"
+                            "type": "string",
+                            "data_type": "node"
                         },
                         "supply_water_storage_tank_name": {
```


### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
