### PR TITLE
Fix an out-of-bounds array access in `WindowManager.cc`

### DIFF
--- a/src/EnergyPlus/WindowManager.cc
+++ b/src/EnergyPlus/WindowManager.cc
@@ -4610,7 +4610,7 @@ namespace Window {
 
             for (int i = 0; i < NMix; ++i) {
                 auto const &wmgasI = wm->gaps[iGap].gases[i];
-                for (int j = 0; j <= NMix; ++j) {
+                for (int j = 0; j < NMix; ++j) {
                     auto const &wmgasJ = wm->gaps[iGap].gases[j];
                     // numerator of equation 61
                     phimup = pow_2(1.0 + std::sqrt(fvis[i] / fvis[j]) * root_4(wmgasJ.wght / wmgasI.wght));

--- a/tst/EnergyPlus/unit/WindowManager.unit.cc
+++ b/tst/EnergyPlus/unit/WindowManager.unit.cc
@@ -7748,11 +7748,11 @@ TEST_F(EnergyPlusFixture, CFS_InteriorSolarDistribution_Test)
 TEST_F(EnergyPlusFixture, WindowManager_WindowGasPropertiesAtTemp_GasMixture)
 {
     auto &wm = state->dataWindowManager;
-    Real64 const T = 273.15; // gap mean temperature [K]
+    Real64 constexpr T = 273.15; // gap mean temperature [K]
 
     // Case 1: two-gas mixture, 10% Air + 90% Argon
     {
-        int const iGap = 0;
+        int constexpr iGap = 0;
         auto &gap = wm->gaps[iGap];
         gap.numGases = 2;
 
@@ -7777,7 +7777,7 @@ TEST_F(EnergyPlusFixture, WindowManager_WindowGasPropertiesAtTemp_GasMixture)
     // The only case where old `j <= NMix` reads truly out of bounds (gases[5] in std::array<Material::Gas, Material::maxMixGases>, and
     // fvis[5]/frct[5] in std::array<Real64, Material::maxMixGases>, all one past the end).
     {
-        int const iGap = 1;
+        int constexpr iGap = 1;
         auto &gap = wm->gaps[iGap];
         gap.numGases = Material::maxMixGases; // 5
         for (int k = 0; k < Material::maxMixGases; ++k) {

--- a/tst/EnergyPlus/unit/WindowManager.unit.cc
+++ b/tst/EnergyPlus/unit/WindowManager.unit.cc
@@ -7744,3 +7744,53 @@ TEST_F(EnergyPlusFixture, CFS_InteriorSolarDistribution_Test)
     EXPECT_EQ(state->dataSolarShading->SurfWinAbsBeam(1), 0.000);
     EXPECT_EQ(state->dataSolarShading->SurfWinAbsBeam(2), 0.000);
 }
+
+TEST_F(EnergyPlusFixture, WindowManager_WindowGasPropertiesAtTemp_GasMixture)
+{
+    auto &wm = state->dataWindowManager;
+    Real64 const T = 273.15; // gap mean temperature [K]
+
+    // Case 1: two-gas mixture, 10% Air + 90% Argon
+    {
+        int const iGap = 0;
+        auto &gap = wm->gaps[iGap];
+        gap.numGases = 2;
+
+        gap.gasFracts[0] = 0.10;
+        gap.gases[0].wght = 28.97;                    // air weight
+        gap.gases[0].vis = {3.723e-6, 4.940e-8, 0.0}; // air viscosity coefficients
+
+        gap.gasFracts[1] = 0.90;
+        gap.gases[1].wght = 39.948;                   // argon weight
+        gap.gases[1].vis = {3.379e-6, 6.451e-8, 0.0}; // argon viscosity coefficients
+
+        Real64 dens = 0.0;
+        Real64 visc = 0.0;
+        WindowGasPropertiesAtTemp(*state, T, iGap, dens, visc);
+
+        // Expected values from the corrected Wilke mixing (j < NMix).
+        EXPECT_NEAR(visc, 2.066268948946603e-05, 1.0e-11);
+        EXPECT_NEAR(dens, 1.710627281762915, 1.0e-9);
+    }
+
+    // Case 2: full five-gas mixture (NMix == maxMixGases == 5)
+    // The only case where old `j <= NMix` reads truly out of bounds (gases[5] in std::array<Material::Gas, Material::maxMixGases>, and
+    // fvis[5]/frct[5] in std::array<Real64, Material::maxMixGases>, all one past the end).
+    {
+        int const iGap = 1;
+        auto &gap = wm->gaps[iGap];
+        gap.numGases = Material::maxMixGases; // 5
+        for (int k = 0; k < Material::maxMixGases; ++k) {
+            gap.gasFracts[k] = 1.0 / Material::maxMixGases;
+            gap.gases[k].wght = 28.97;
+            gap.gases[k].vis = {3.723e-6, 4.940e-8, 0.0};
+        }
+
+        Real64 dens = 0.0;
+        Real64 visc = 0.0;
+        WindowGasPropertiesAtTemp(*state, T, iGap, dens, visc);
+
+        Real64 const singleGasVisc = 3.723e-6 + 4.940e-8 * T; // = 1.721661e-05
+        EXPECT_NEAR(visc, singleGasVisc, 1.0e-11);
+    }
+}


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11561 
- In `WindowGasPropertiesAtTemp()` [here](https://github.com/NatLabRockies/EnergyPlus/blob/develop/src/EnergyPlus/WindowManager.cc#L4613), inner viscosity loop used `j <= NMix`, reading one element past the end of `gases/fvis/frct`. Changed to `j < NMix`.
- Impact: only affects between-glass shade/blind windows with a gas mixture gap (`NMix ≥ 2`); at `NMix == maxMixGases (5)` it's a genuine out-of-bounds read.
- Added a unit test since this code line was not covered by any unit tests. The unit test covers a 2-gas mixture (checks correct viscosity/density) and a full 5-gas mixture (the true out-of-bounds case).

<!-- NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE -->

### Description of the purpose of this PR

<!-- DESCRIBE PURPOSE OF THIS PULL REQUEST -->

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
