### PR TITLE
Fix incorrect note on HeatPump:AirToWater cooling-mode rated leaving water temperature

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -76523,8 +76523,8 @@ HeatPump:AirToWater,
         \type real
         \units C
         \default 8
-        \note inlet water temperature corresponding to rated performance
-        \note (heating capacity, COP).
+        \note outlet water temperature corresponding to rated heat pump performance
+        \note (cooling capacity, COP).
    N12 , \field Rated Water Flow Rate in Cooling Mode
         \type real
         \units m3/s


### PR DESCRIPTION
Pull request overview
---------------------

### Description of the purpose of this PR

Documentation-only fix in the IDD. The `\note` on `HeatPump:AirToWater` field N11, `Rated Leaving Water Temperature in Cooling Mode`, describes an inlet temperature and refers to heating capacity:

```
   N11 , \field Rated Leaving Water Temperature in Cooling Mode
        \type real
        \units C
        \default 8
        \note inlet water temperature corresponding to rated performance
        \note (heating capacity, COP).
```

Both look like leftovers from the heating field N4 just above it, which carries the same "(heating capacity, COP)" wording.

The field name is right and the note is wrong:

- The Input/Output Reference already documents this field correctly, as "the outlet water temperature corresponding to rated heat pump performance (capacity, COP)".
- `PlantLoopHeatPumpEIR.cc` evaluates the capacity and EIR curves on `loadSideOutletTemp` / `loadSideOutletSetpointTemp`.
- The 8 C default is a leaving chilled water temperature. An entering value at rated conditions would sit well above that.

Changed to:

```
        \note outlet water temperature corresponding to rated heat pump performance
        \note (cooling capacity, COP).
```

That is two comment lines in `idd/Energy+.idd.in`. No behavior change and no test impact. I don't believe it needs transition since no field name, type, default, or order changes, but happy to add the label if that's not the convention here.

Found while looking at `HeatPump:AirToWater` as the translation target for air-to-water heat pumps in HPXML and OpenStudio-HPXML.

### Pull Request Author

 - [x] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [x] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [x] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair — N/A, no code changes
 - [x] Author should provide a "walkthrough" of relevant code changes — the whole diff is the two lines quoted above
 - [x] If any diffs are expected, author must demonstrate they are justified using plots and descriptions — N/A, no results diffs
 - [x] If IDD requires transition ... add IDDChange label — no transition expected, see note above
 - [x] If structural output changes, add to output rules file — N/A
 - [x] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies — N/A
 - [x] If adding/removing any output files — N/A

One process question: `.github/contributing.md` points to a contribution policy page at energyplus.net/contributing for the required external-contributor steps, and that URL currently returns a 404. Happy to complete whatever licence or agreement step is needed — please point me at the current location.
