### PR TITLE
Air-cooled chiller sizing can cause RH > 100 warnings.

### DIFF
--- a/idd/Energy+.idd.in
+++ b/idd/Energy+.idd.in
@@ -75871,8 +75871,9 @@ Chiller:Electric,
        \autosizable
        \minimum 0.0
        \ip-units gal/min
-       \note This field is only used for Condenser Type = AirCooled or EvaporativelyCooled
-       \note when Heat Recovery is specified
+       \note For Condenser Type = AirCooled or EvaporativelyCooled, this flow rate is used to
+       \note calculate the condenser outlet node conditions. If this field is blank or Autosize,
+       \note the flow rate is estimated using 850 cfm/ton of nominal capacity.
   N11, \field Coefficient 1 of Capacity Ratio Curve
   N12, \field Coefficient 2 of Capacity Ratio Curve
   N13, \field Coefficient 3 of Capacity Ratio Curve

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -1996,6 +1996,8 @@ namespace PlantChillers {
             if (this->CondenserType != DataPlant::CondenserType::WaterCooled) {
                 state.dataLoopNodes->Node(this->CondOutletNodeNum).HumRat = state.dataLoopNodes->Node(this->CondInletNodeNum).HumRat;
                 state.dataLoopNodes->Node(this->CondOutletNodeNum).Enthalpy = state.dataLoopNodes->Node(this->CondInletNodeNum).Enthalpy;
+                state.dataLoopNodes->Node(this->CondInletNodeNum).MassFlowRate = this->CondMassFlowRate;
+                state.dataLoopNodes->Node(this->CondOutletNodeNum).MassFlowRate = this->CondMassFlowRate;
             }
 
             this->EvapInletTemp = state.dataLoopNodes->Node(this->EvapInletNodeNum).Temp;
@@ -2025,13 +2027,13 @@ namespace PlantChillers {
                 state.dataLoopNodes->Node(this->CondOutletNodeNum).HumRat = this->CondOutletHumRat;
                 state.dataLoopNodes->Node(this->CondOutletNodeNum).Enthalpy =
                     Psychrometrics::PsyHFnTdbW(this->CondOutletTemp, this->CondOutletHumRat);
+                state.dataLoopNodes->Node(this->CondInletNodeNum).MassFlowRate = this->CondMassFlowRate;
+                state.dataLoopNodes->Node(this->CondOutletNodeNum).MassFlowRate = this->CondMassFlowRate;
             }
             // set node flow rates;  for these load based models
             // assume that the sufficient evaporator flow rate available
             this->EvapInletTemp = state.dataLoopNodes->Node(this->EvapInletNodeNum).Temp;
             this->CondInletTemp = state.dataLoopNodes->Node(this->CondInletNodeNum).Temp;
-            this->CondOutletTemp = state.dataLoopNodes->Node(this->CondOutletNodeNum).Temp;
-            this->EvapOutletTemp = state.dataLoopNodes->Node(this->EvapOutletNodeNum).Temp;
             if (this->CondenserType == DataPlant::CondenserType::EvapCooled) {
                 this->BasinHeaterConsumption = this->BasinHeaterPower * ReportingConstant;
             }

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -1145,7 +1145,7 @@ namespace PlantChillers {
         PlantUtilities::RegisterPlantCompDesignFlow(state, this->EvapInletNodeNum, tmpEvapVolFlowRate);
 
         Real64 tmpCondVolFlowRate = this->CondVolFlowRate;
-        if (PltSizCondNum > 0 && PltSizNum > 0) {
+        if (PltSizCondNum > 0 && PltSizNum > 0 && this->CondenserType == DataPlant::CondenserType::WaterCooled) {
             if (state.dataSize->PlantSizData(PltSizNum).DesVolFlowRate >= HVAC::SmallWaterVolFlow && tmpNomCap > 0.0) {
                 Real64 rho = this->CDPlantLoc.loop->glycol->getDensity(state, this->TempDesCondIn, RoutineName);
                 Real64 Cp = this->CDPlantLoc.loop->glycol->getSpecificHeat(state, this->TempDesCondIn, RoutineName);
@@ -1197,12 +1197,13 @@ namespace PlantChillers {
             }
         } else {
             if (this->CondVolFlowRateWasAutoSized && state.dataPlnt->PlantFirstSizesOkayToFinalize) {
-                ShowSevereError(state, "Autosizing of Electric Chiller condenser flow rate requires a condenser");
+                ShowSevereError(state, "Autosizing of Electric Chiller condenser waterflow rate requires a condenser");
                 ShowContinueError(state, "loop Sizing:Plant object");
                 ShowContinueError(state, std::format("Occurs in Electric Chiller object={}", this->Name));
                 ErrorsFound = true;
             }
-            if (!this->CondVolFlowRateWasAutoSized && state.dataPlnt->PlantFinalSizesOkayToReport && (this->CondVolFlowRate > 0.0)) {
+            if (this->CondenserType == DataPlant::CondenserType::WaterCooled && !this->CondVolFlowRateWasAutoSized &&
+                state.dataPlnt->PlantFinalSizesOkayToReport && this->CondVolFlowRate > 0.0) {
                 BaseSizer::reportSizerOutput(
                     state, "Chiller:Electric", this->Name, "User-Specified Design Condenser Water Flow Rate [m3/s]", this->CondVolFlowRate);
             }
@@ -1213,8 +1214,24 @@ namespace PlantChillers {
             PlantUtilities::RegisterPlantCompDesignFlow(state, this->CondInletNodeNum, tmpCondVolFlowRate);
         } else {
             // sizing of condenser flow for air/evap-cooled is not reported but the condenser side deltaT is calculated, so at least make it realistic
-            if (this->CondVolFlowRate == DataSizing::AutoSize && state.dataPlnt->PlantFinalSizesOkayToReport) {
-                this->CondVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
+            if (state.dataPlnt->PlantFinalSizesOkayToReport) {
+                Real64 const desAirVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
+                if (this->CondVolFlowRate == DataSizing::AutoSize) {
+                    this->CondVolFlowRate = desAirVolFlowRate;
+                    BaseSizer::reportSizerOutput(
+                        state, "Chiller:Electric", this->Name, "Design Size Design Condenser Fluid Flow Rate [m3/s]", this->CondVolFlowRate);
+                } else if (std::abs((this->CondVolFlowRate - desAirVolFlowRate) / desAirVolFlowRate) > state.dataSize->AutoVsHardSizingThreshold) {
+                    ShowWarningError(state, std::format("User-specified Design Condenser Fluid Flow Rate = {:.5f} [m3/s]", this->CondVolFlowRate));
+                    ShowContinueError(state,
+                                      std::format("differs from design size design condenser fluid flow rate = {:.5f} [m3/s]", desAirVolFlowRate));
+                    ShowContinueError(state, "This may, or may not, indicate mismatched component sizes.");
+                    ShowContinueError(state, "Verify that the value entered is intended and is consistent with other components.");
+                    ShowContinueError(state, std::format("Occurs in Electric Chiller object={}", this->Name));
+                    BaseSizer::reportSizerOutput(
+                        state, "Chiller:Electric", this->Name, "Design Size Design Condenser Fluid Flow Rate [m3/s]", desAirVolFlowRate);
+                    BaseSizer::reportSizerOutput(
+                        state, "Chiller:Electric", this->Name, "User-Specified Design Condenser Fluid Flow Rate [m3/s]", this->CondVolFlowRate);
+                }
             }
         }
         if (ErrorsFound) {

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -1197,7 +1197,7 @@ namespace PlantChillers {
             }
         } else {
             if (this->CondVolFlowRateWasAutoSized && state.dataPlnt->PlantFirstSizesOkayToFinalize) {
-                ShowSevereError(state, "Autosizing of Electric Chiller condenser waterflow rate requires a condenser");
+                ShowSevereError(state, "Autosizing of Electric Chiller condenser water flow rate requires a condenser");
                 ShowContinueError(state, "loop Sizing:Plant object");
                 ShowContinueError(state, std::format("Occurs in Electric Chiller object={}", this->Name));
                 ErrorsFound = true;

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -556,11 +556,7 @@ namespace PlantChillers {
                 thisChiller.DesignHeatRecMassFlowRate = 0.0;
                 thisChiller.HeatRecInletNodeNum = 0;
                 thisChiller.HeatRecOutletNodeNum = 0;
-                // if heat recovery is not used, don't care about condenser flow rate for air/evap-cooled equip.
-                if (thisChiller.CondenserType == DataPlant::CondenserType::AirCooled ||
-                    thisChiller.CondenserType == DataPlant::CondenserType::EvapCooled) {
-                    thisChiller.CondVolFlowRate = 0.0011; // set to avoid errors in calc routine
-                }
+
                 if ((!state.dataIPShortCut->lAlphaFieldBlanks(8)) || (!state.dataIPShortCut->lAlphaFieldBlanks(9))) {
                     ShowWarningError(state,
                                      std::format("Since Design Heat Flow Rate = 0.0, Heat Recovery inactive for {}={}",
@@ -1215,6 +1211,11 @@ namespace PlantChillers {
         // save the design condenser water volumetric flow rate for use by the condenser water loop sizing algorithms
         if (this->CondenserType == DataPlant::CondenserType::WaterCooled) {
             PlantUtilities::RegisterPlantCompDesignFlow(state, this->CondInletNodeNum, tmpCondVolFlowRate);
+        } else {
+            // sizing of condenser flow for air/evap-cooled is not reported but the condenser side deltaT is calculated, so at least make it realistic
+            if (this->CondVolFlowRate == DataSizing::AutoSize && state.dataPlnt->PlantFinalSizesOkayToReport) {
+                this->CondVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
+            }
         }
         if (ErrorsFound) {
             ShowFatalError(state, "Preceding sizing errors cause program termination");
@@ -2577,11 +2578,7 @@ namespace PlantChillers {
                 thisChiller.DesignHeatRecMassFlowRate = 0.0;
                 thisChiller.HeatRecInletNodeNum = 0;
                 thisChiller.HeatRecOutletNodeNum = 0;
-                // if heat recovery is not used, don't care about condenser flow rate for air/evap-cooled equip.
-                if (thisChiller.CondenserType == DataPlant::CondenserType::AirCooled ||
-                    thisChiller.CondenserType == DataPlant::CondenserType::EvapCooled) {
-                    thisChiller.CondVolFlowRate = 0.0011; // set to avoid errors in calc routine
-                }
+
                 if ((!state.dataIPShortCut->lAlphaFieldBlanks(13)) || (!state.dataIPShortCut->lAlphaFieldBlanks(14))) {
                     ShowWarningError(state,
                                      std::format("Since Design Heat Flow Rate = 0.0, Heat Recovery inactive for {}={}",
@@ -3248,6 +3245,11 @@ namespace PlantChillers {
         // save the design condenser water volumetric flow rate for use by the condenser water loop sizing algorithms
         if (this->CondenserType == DataPlant::CondenserType::WaterCooled) {
             PlantUtilities::RegisterPlantCompDesignFlow(state, this->CondInletNodeNum, tmpCondVolFlowRate);
+        } else {
+            // sizing of condenser flow for air/evap-cooled is not reported but the condenser side deltaT is calculated, so at least make it realistic
+            if (this->CondVolFlowRate == DataSizing::AutoSize && state.dataPlnt->PlantFinalSizesOkayToReport) {
+                this->CondVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
+            }
         }
 
         // autosize support for heat recovery flow rate.
@@ -4573,10 +4575,6 @@ namespace PlantChillers {
                                                  state.dataIPShortCut->cAlphaArgs(1)));
                     ShowContinueError(state, "However, Node names were specified for heat recovery inlet or outlet nodes");
                 }
-                if (thisChiller.CondenserType == DataPlant::CondenserType::AirCooled ||
-                    thisChiller.CondenserType == DataPlant::CondenserType::EvapCooled) {
-                    thisChiller.CondVolFlowRate = 0.0011; // set to avoid errors in calc routine
-                }
             }
 
             thisChiller.FlowMode = static_cast<DataPlant::FlowMode>(getEnumValue(DataPlant::FlowModeNamesUC, state.dataIPShortCut->cAlphaArgs(9)));
@@ -5214,6 +5212,11 @@ namespace PlantChillers {
         // save the design condenser water volumetric flow rate for use by the condenser water loop sizing algorithms
         if (this->CondenserType == DataPlant::CondenserType::WaterCooled) {
             PlantUtilities::RegisterPlantCompDesignFlow(state, this->CondInletNodeNum, tmpCondVolFlowRate);
+        } else {
+            // sizing of condenser flow for air/evap-cooled is not reported but the condenser side deltaT is calculated, so at least make it realistic
+            if (this->CondVolFlowRate == DataSizing::AutoSize && state.dataPlnt->PlantFinalSizesOkayToReport) {
+                this->CondVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
+            }
         }
 
         Real64 GTEngineCapacityDes = this->NomCap / (this->engineCapacityScalar * this->COP);
@@ -6269,15 +6272,10 @@ namespace PlantChillers {
             if (thisChiller.EvapVolFlowRate == DataSizing::AutoSize) {
                 thisChiller.EvapVolFlowRateWasAutoSized = true;
             }
-            if (thisChiller.CondenserType == DataPlant::CondenserType::AirCooled ||
-                thisChiller.CondenserType == DataPlant::CondenserType::EvapCooled) { // Condenser flow rate not used for these cond types
-                thisChiller.CondVolFlowRate = 0.0011;
-            } else {
-                thisChiller.CondVolFlowRate = state.dataIPShortCut->rNumericArgs(4);
-                if (thisChiller.CondVolFlowRate == DataSizing::AutoSize) {
-                    if (thisChiller.CondenserType == DataPlant::CondenserType::WaterCooled) {
-                        thisChiller.CondVolFlowRateWasAutoSized = true;
-                    }
+            thisChiller.CondVolFlowRate = state.dataIPShortCut->rNumericArgs(4);
+            if (thisChiller.CondVolFlowRate == DataSizing::AutoSize) {
+                if (thisChiller.CondenserType == DataPlant::CondenserType::WaterCooled) {
+                    thisChiller.CondVolFlowRateWasAutoSized = true;
                 }
             }
             thisChiller.SizFac = state.dataIPShortCut->rNumericArgs(5);
@@ -6972,6 +6970,11 @@ namespace PlantChillers {
         // save the design condenser water volumetric flow rate for use by the condenser water loop sizing algorithms
         if (this->CondenserType == DataPlant::CondenserType::WaterCooled) {
             PlantUtilities::RegisterPlantCompDesignFlow(state, this->CondInletNodeNum, tmpCondVolFlowRate);
+        } else {
+            // sizing of condenser flow for air/evap-cooled is not reported but the condenser side deltaT is calculated, so at least make it realistic
+            if (this->CondVolFlowRate == DataSizing::AutoSize && state.dataPlnt->PlantFinalSizesOkayToReport) {
+                this->CondVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
+            }
         }
 
         if (ErrorsFound) {

--- a/src/EnergyPlus/PlantChillers.cc
+++ b/src/EnergyPlus/PlantChillers.cc
@@ -503,10 +503,11 @@ namespace PlantChillers {
                 if (thisChiller.DesignHeatRecVolFlowRate > 0.0) {
                     PlantUtilities::RegisterPlantCompDesignFlow(state, thisChiller.HeatRecInletNodeNum, thisChiller.DesignHeatRecVolFlowRate);
                 }
-                // Condenser flow rate must be specified for heat reclaim
+                // Condenser flow rate must be specified or sized for heat reclaim
                 if (thisChiller.CondenserType == DataPlant::CondenserType::AirCooled ||
                     thisChiller.CondenserType == DataPlant::CondenserType::EvapCooled) {
-                    if (thisChiller.CondVolFlowRate <= 0.0) {
+                    if (thisChiller.CondVolFlowRate <= 0.0 && thisChiller.CondVolFlowRate != DataSizing::AutoSize &&
+                        !state.dataIPShortCut->lNumericFieldBlanks(10)) {
                         ShowSevereError(
                             state,
                             std::format("Invalid {}={:.6f}", state.dataIPShortCut->cNumericFieldNames(10), state.dataIPShortCut->rNumericArgs(10)));
@@ -1216,7 +1217,7 @@ namespace PlantChillers {
             // sizing of condenser flow for air/evap-cooled is not reported but the condenser side deltaT is calculated, so at least make it realistic
             if (state.dataPlnt->PlantFinalSizesOkayToReport) {
                 Real64 const desAirVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)
-                if (this->CondVolFlowRate == DataSizing::AutoSize) {
+                if (this->CondVolFlowRate == DataSizing::AutoSize || this->CondVolFlowRate == 0.0) {
                     this->CondVolFlowRate = desAirVolFlowRate;
                     BaseSizer::reportSizerOutput(
                         state, "Chiller:Electric", this->Name, "Design Size Design Condenser Fluid Flow Rate [m3/s]", this->CondVolFlowRate);

--- a/testfiles/5ZoneWaterLoopHeatPump.idf
+++ b/testfiles/5ZoneWaterLoopHeatPump.idf
@@ -3305,7 +3305,7 @@
     2.778,                   !- Temperature Rise Coefficient
     6.67,                    !- Design Chilled Water Outlet Temperature {C}
     0.007,                   !- Design Chilled Water Flow Rate {m3/s}
-    0.001,                   !- Design Condenser Fluid Flow Rate {m3/s}
+    22.8,                    !- Design Condenser Fluid Flow Rate {m3/s}
     0.9949,                  !- Coefficient 1 of Capacity Ratio Curve
     -0.045954,               !- Coefficient 2 of Capacity Ratio Curve
     -0.0013543,              !- Coefficient 3 of Capacity Ratio Curve

--- a/testfiles/AirCooledElectricChiller.idf
+++ b/testfiles/AirCooledElectricChiller.idf
@@ -1429,8 +1429,8 @@
     35.0,                    !- Design Condenser Inlet Temperature {C}
     2.778,                   !- Temperature Rise Coefficient
     6.67,                    !- Design Chilled Water Outlet Temperature {C}
-    11.4,                    !- Design Chilled Water Flow Rate {m3/s}
-    0.002,                   !- Design Condenser Fluid Flow Rate {m3/s}
+    0.0011,                  !- Design Chilled Water Flow Rate {m3/s}
+    11.4,                    !- Design Condenser Fluid Flow Rate {m3/s}
     0.9949,                  !- Coefficient 1 of Capacity Ratio Curve
     -0.045954,               !- Coefficient 2 of Capacity Ratio Curve
     -0.0013543,              !- Coefficient 3 of Capacity Ratio Curve

--- a/testfiles/AirCooledElectricChiller.idf
+++ b/testfiles/AirCooledElectricChiller.idf
@@ -1429,7 +1429,7 @@
     35.0,                    !- Design Condenser Inlet Temperature {C}
     2.778,                   !- Temperature Rise Coefficient
     6.67,                    !- Design Chilled Water Outlet Temperature {C}
-    0.0011,                  !- Design Chilled Water Flow Rate {m3/s}
+    11.4,                    !- Design Chilled Water Flow Rate {m3/s}
     0.002,                   !- Design Condenser Fluid Flow Rate {m3/s}
     0.9949,                  !- Coefficient 1 of Capacity Ratio Curve
     -0.045954,               !- Coefficient 2 of Capacity Ratio Curve

--- a/testfiles/UnitarySystem_5ZoneWaterLoopHeatPump.idf
+++ b/testfiles/UnitarySystem_5ZoneWaterLoopHeatPump.idf
@@ -3784,7 +3784,7 @@
     2.778,                   !- Temperature Rise Coefficient
     6.67,                    !- Design Chilled Water Outlet Temperature {C}
     0.007,                   !- Design Chilled Water Flow Rate {m3/s}
-    0.001,                   !- Design Condenser Fluid Flow Rate {m3/s}
+    28.5,                    !- Design Condenser Fluid Flow Rate {m3/s}
     0.9949,                  !- Coefficient 1 of Capacity Ratio Curve
     -0.045954,               !- Coefficient 2 of Capacity Ratio Curve
     -0.0013543,              !- Coefficient 3 of Capacity Ratio Curve

--- a/tst/EnergyPlus/unit/PlantChillers.unit.cc
+++ b/tst/EnergyPlus/unit/PlantChillers.unit.cc
@@ -155,7 +155,8 @@ TEST_F(EnergyPlusFixture, ElectricChiller_AirCooled_HardAndAutoSizing)
     EXPECT_DOUBLE_EQ(ch.NomCap, 50000.0);
     state->dataPlnt->PlantFinalSizesOkayToReport = true;
     ch.size(*state);
-    EXPECT_DOUBLE_EQ(ch.CondVolFlowRate, 5.7);
+    Real64 const expectedCondVol = ch.NomCap * 0.000114;
+    EXPECT_NEAR(ch.CondVolFlowRate, expectedCondVol, 1e-9);
 }
 
 TEST_F(EnergyPlusFixture, ElectricChiller_CondVolFlowSizingSimple)
@@ -214,9 +215,9 @@ TEST_F(EnergyPlusFixture, ElectricChiller_CondVolFlowSizingSimple)
     // Compute expected cond volumetric flow per sizing formula in PlantChillers.cc
     static constexpr std::string_view RoutineName("UnitTest");
 
-    Real64 rhoCond = ch.CDPlantLoc.loop->glycol->getDensity(*state, ch.TempDesCondIn, RoutineName);
-    Real64 CpCond = ch.CDPlantLoc.loop->glycol->getSpecificHeat(*state, ch.TempDesCondIn, RoutineName);
-    Real64 expectedCondVol = ch.NomCap * (1.0 + 1.0 / ch.COP) / (state->dataSize->PlantSizData(2).DeltaT * CpCond * rhoCond);
+    Real64 const rhoCond = ch.CDPlantLoc.loop->glycol->getDensity(*state, ch.TempDesCondIn, RoutineName);
+    Real64 const CpCond = ch.CDPlantLoc.loop->glycol->getSpecificHeat(*state, ch.TempDesCondIn, RoutineName);
+    Real64 const expectedCondVol = ch.NomCap * (1.0 + 1.0 / ch.COP) / (state->dataSize->PlantSizData(2).DeltaT * CpCond * rhoCond);
 
     EXPECT_NEAR(ch.CondVolFlowRate, expectedCondVol, 1e-9);
 }

--- a/tst/EnergyPlus/unit/PlantChillers.unit.cc
+++ b/tst/EnergyPlus/unit/PlantChillers.unit.cc
@@ -103,6 +103,124 @@ TEST_F(EnergyPlusFixture, GTChiller_HeatRecoveryAutosizeTest)
     state->dataPlnt->PlantLoop.deallocate();
 }
 
+TEST_F(EnergyPlusFixture, ElectricChiller_AirCooled_HardAndAutoSizing)
+{
+    state->init_state(*state);
+
+    // Allocate plant loops and sizing data for chilled water only
+    state->dataPlnt->PlantLoop.allocate(1);
+    state->dataSize->PlantSizData.allocate(1);
+
+    // set sizing index and fluid for chilled water
+    state->dataPlnt->PlantLoop(1).PlantSizNum = 1;
+    state->dataPlnt->PlantLoop(1).FluidName = "WATER";
+    state->dataPlnt->PlantLoop(1).glycol = Fluid::GetWater(*state);
+
+    // Provide plant sizing data
+    state->dataSize->PlantSizData(1).DesVolFlowRate = 0.001; // >= SmallWaterVolFlow
+    state->dataSize->PlantSizData(1).DeltaT = 5.0;
+
+    // Finalize sizing allowed
+    state->dataPlnt->PlantFirstSizesOkayToFinalize = true;
+    state->dataPlnt->PlantFirstSizesOkayToReport = true;
+    state->dataPlnt->PlantFinalSizesOkayToReport = false;
+
+    // Allocate and configure electric chiller (air-cooled)
+    state->dataPlantChillers->ElectricChiller.allocate(1);
+    auto &ch = state->dataPlantChillers->ElectricChiller(1);
+    ch.Name = "TestElectricChillerAir";
+    ch.CondenserType = DataPlant::CondenserType::AirCooled;
+    ch.NomCap = 50000.0; // W
+    ch.NomCapWasAutoSized = false;
+    ch.COP = 3.5;
+    ch.SizFac = 1.0;
+
+    // link chilled water loop only
+    ch.CWPlantLoc.loopNum = 1;
+    PlantUtilities::SetPlantLocationLinks(*state, ch.CWPlantLoc);
+
+    // Case 1: Hard-sized condenser volumetric flow remains unchanged after sizing
+    ch.CondVolFlowRate = 0.0005;
+    ch.CondVolFlowRateWasAutoSized = false;
+    ch.TempDesCondIn = 30.0; // not used for air-cooled path
+
+    ch.size(*state);
+    EXPECT_DOUBLE_EQ(ch.CondVolFlowRate, 0.0005);
+
+    // Case 2: Autosize condenser volumetric flow with air-cooled and no condenser loop
+    ch.CondVolFlowRate = DataSizing::AutoSize;
+    ch.CondVolFlowRateWasAutoSized = false; // for air-cooled chillers this flag should not be true
+    ch.size(*state);
+    EXPECT_DOUBLE_EQ(ch.CondVolFlowRate, DataSizing::AutoSize);
+    EXPECT_DOUBLE_EQ(ch.NomCap, 50000.0);
+    state->dataPlnt->PlantFinalSizesOkayToReport = true;
+    ch.size(*state);
+    EXPECT_DOUBLE_EQ(ch.CondVolFlowRate, 5.7);
+}
+
+TEST_F(EnergyPlusFixture, ElectricChiller_CondVolFlowSizingSimple)
+{
+    state->init_state(*state);
+
+    // Allocate plant loops and sizing data
+    state->dataPlnt->PlantLoop.allocate(2);
+    state->dataSize->PlantSizData.allocate(2);
+
+    // set sizing indices and fluid
+    state->dataPlnt->PlantLoop(1).PlantSizNum = 1;
+    state->dataPlnt->PlantLoop(1).FluidName = "WATER";
+    state->dataPlnt->PlantLoop(1).glycol = Fluid::GetWater(*state);
+    state->dataPlnt->PlantLoop(2).PlantSizNum = 2;
+    state->dataPlnt->PlantLoop(2).FluidName = "WATER";
+    state->dataPlnt->PlantLoop(2).glycol = Fluid::GetWater(*state);
+
+    // Provide plant sizing data (evap cond indexes 1 & 2)
+    state->dataSize->PlantSizData(1).DesVolFlowRate = 0.001; // >= SmallWaterVolFlow
+    state->dataSize->PlantSizData(1).DeltaT = 5.0;
+    state->dataSize->PlantSizData(2).DesVolFlowRate = 0.002;
+    state->dataSize->PlantSizData(2).DeltaT = 5.0;
+
+    // Finalize sizing allowed
+    state->dataPlnt->PlantFirstSizesOkayToFinalize = true;
+    state->dataPlnt->PlantFirstSizesOkayToReport = true;
+    state->dataPlnt->PlantFinalSizesOkayToReport = false;
+
+    // Allocate and configure electric chiller
+    state->dataPlantChillers->ElectricChiller.allocate(1);
+    auto &ch = state->dataPlantChillers->ElectricChiller(1);
+    ch.Name = "TestElectricChiller";
+    ch.CondenserType = DataPlant::CondenserType::WaterCooled;
+    ch.NomCap = 100000.0; // W (will be overridden by tmpNomCap calculation)
+    ch.NomCapWasAutoSized = false;
+    ch.COP = 4.0;
+    ch.SizFac = 1.0;
+
+    // link plant loops
+    ch.CWPlantLoc.loopNum = 1;
+    ch.CDPlantLoc.loopNum = 2;
+    PlantUtilities::SetPlantLocationLinks(*state, ch.CWPlantLoc);
+    PlantUtilities::SetPlantLocationLinks(*state, ch.CDPlantLoc);
+
+    // mark condenser flow to be autosized
+    ch.CondVolFlowRate = DataSizing::AutoSize;
+    ch.CondVolFlowRateWasAutoSized = true;
+
+    // ensure TempDesCondIn used for density/cp lookup
+    ch.TempDesCondIn = 25.0;
+
+    // Call size
+    ch.size(*state);
+
+    // Compute expected cond volumetric flow per sizing formula in PlantChillers.cc
+    static constexpr std::string_view RoutineName("UnitTest");
+
+    Real64 rhoCond = ch.CDPlantLoc.loop->glycol->getDensity(*state, ch.TempDesCondIn, RoutineName);
+    Real64 CpCond = ch.CDPlantLoc.loop->glycol->getSpecificHeat(*state, ch.TempDesCondIn, RoutineName);
+    Real64 expectedCondVol = ch.NomCap * (1.0 + 1.0 / ch.COP) / (state->dataSize->PlantSizData(2).DeltaT * CpCond * rhoCond);
+
+    EXPECT_NEAR(ch.CondVolFlowRate, expectedCondVol, 1e-9);
+}
+
 TEST_F(EnergyPlusFixture, EngineDrivenChiller_HeatRecoveryAutosizeTest)
 {
     state->init_state(*state);

--- a/tst/EnergyPlus/unit/PlantChillers.unit.cc
+++ b/tst/EnergyPlus/unit/PlantChillers.unit.cc
@@ -157,6 +157,56 @@ TEST_F(EnergyPlusFixture, ElectricChiller_AirCooled_HardAndAutoSizing)
     ch.size(*state);
     Real64 const expectedCondVol = ch.NomCap * 0.000114;
     EXPECT_NEAR(ch.CondVolFlowRate, expectedCondVol, 1e-9);
+
+    // Case 3: A blank numeric input is passed to the model as zero and receives the default sizing
+    ch.CondVolFlowRate = 0.0;
+    ch.size(*state);
+    EXPECT_NEAR(ch.CondVolFlowRate, expectedCondVol, 1e-9);
+}
+
+TEST_F(EnergyPlusFixture, ElectricChiller_AirCooled_HeatRecoveryAllowsAutosizedCondenserFlow)
+{
+    std::string const idf_objects = delimited_string({
+        "Chiller:Electric,",
+        "  Air Cooled Chiller,       !- Name",
+        "  AirCooled,                 !- Condenser Type",
+        "  50000,                     !- Nominal Capacity {W}",
+        "  3.5,                       !- Nominal COP {W/W}",
+        "  Chilled Water Inlet Node,  !- Chilled Water Inlet Node Name",
+        "  Chilled Water Outlet Node, !- Chilled Water Outlet Node Name",
+        "  Condenser Inlet Node,      !- Condenser Inlet Node Name",
+        "  Condenser Outlet Node,     !- Condenser Outlet Node Name",
+        "  0.15,                      !- Minimum Part Load Ratio",
+        "  1.0,                       !- Maximum Part Load Ratio",
+        "  0.65,                      !- Optimum Part Load Ratio",
+        "  35.0,                      !- Design Condenser Inlet Temperature {C}",
+        "  2.778,                     !- Temperature Rise Coefficient",
+        "  6.67,                      !- Design Chilled Water Outlet Temperature {C}",
+        "  0.0011,                    !- Design Chilled Water Flow Rate {m3/s}",
+        "  Autosize,                  !- Design Condenser Fluid Flow Rate {m3/s}",
+        "  0.9949,                    !- Coefficient 1 of Capacity Ratio Curve",
+        "  -0.045954,                 !- Coefficient 2 of Capacity Ratio Curve",
+        "  -0.0013543,                !- Coefficient 3 of Capacity Ratio Curve",
+        "  2.333,                     !- Coefficient 1 of Power Ratio Curve",
+        "  -1.975,                    !- Coefficient 2 of Power Ratio Curve",
+        "  0.6121,                    !- Coefficient 3 of Power Ratio Curve",
+        "  0.03303,                   !- Coefficient 1 of Full Load Ratio Curve",
+        "  0.6852,                    !- Coefficient 2 of Full Load Ratio Curve",
+        "  0.2818,                    !- Coefficient 3 of Full Load Ratio Curve",
+        "  5.0,                       !- Chilled Water Outlet Temperature Lower Limit {C}",
+        "  NotModulated,              !- Chiller Flow Mode",
+        "  0.00055,                   !- Design Heat Recovery Water Flow Rate {m3/s}",
+        "  Heat Recovery Inlet Node,  !- Heat Recovery Inlet Node Name",
+        "  Heat Recovery Outlet Node; !- Heat Recovery Outlet Node Name",
+    });
+
+    ASSERT_TRUE(process_idf(idf_objects));
+    state->init_state(*state);
+
+    EXPECT_NO_THROW(ElectricChillerSpecs::getInput(*state));
+    ASSERT_EQ(1, state->dataPlantChillers->NumElectricChillers);
+    EXPECT_TRUE(state->dataPlantChillers->ElectricChiller(1).HeatRecActive);
+    EXPECT_EQ(DataSizing::AutoSize, state->dataPlantChillers->ElectricChiller(1).CondVolFlowRate);
 }
 
 TEST_F(EnergyPlusFixture, ElectricChiller_CondVolFlowSizingSimple)


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #7134 
<!-- NOTE: ENHANCEMENTS MUST FOLLOW A SUBMISSION PROCESS INCLUDING A FEATURE PROPOSAL AND DESIGN DOCUMENT PRIOR TO SUBMITTING CODE -->

### Description of the purpose of this PR

Plant chillers calculates a condenser fluid outlet temperature. If the condenser fluid (air) flow rate is not accurately represented then the outlet temperature is not correct. The air-cooled condenser water and outlet air temp are not reported but do set a NODE condition and therefore should be calculated in good faith. 

Correction changes: this->CondMassFlowRate to a more reasonable value

    this->CondVolFlowRate = this->NomCap * 0.000114; // m3/s/w (850 cfm/ton)

    Real64 CpCond = Psychrometrics::PsyCpAirFnW(state.dataLoopNodes->Node(this->CondInletNodeNum).HumRat);
    this->CondOutletTemp = condInletTemp + this->QCondenser / this->CondMassFlowRate / CpCond;


### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
