### PR TITLE
Fix for Hard Crash when Operative Temperature Controls are Combined with Kiva in a Single Simulation

### DIFF
--- a/src/EnergyPlus/HeatBalanceAirManager.cc
+++ b/src/EnergyPlus/HeatBalanceAirManager.cc
@@ -291,6 +291,11 @@ void GetSimpleAirModelInputs(EnergyPlusData &state, bool &ErrorsFound) // IF err
 
     RepVarSet.dimension(state.dataGlobal->NumOfZones, true);
 
+    // Following used for reporting
+    if (state.dataHeatBal->doSpaceHeatBalanceSizing || state.dataHeatBal->doSpaceHeatBalanceSimulation) {
+        state.dataHeatBal->spaceAirRpt.allocate(state.dataGlobal->numSpaces);
+    }
+
     for (int Loop = 1; Loop <= state.dataGlobal->NumOfZones; ++Loop) {
         std::string const &name = state.dataHeatBal->Zone(Loop).Name;
         auto &thisZnAirRpt = state.dataHeatBal->ZnAirRpt(Loop);

--- a/src/EnergyPlus/HeatBalanceAirManager.cc
+++ b/src/EnergyPlus/HeatBalanceAirManager.cc
@@ -291,12 +291,6 @@ void GetSimpleAirModelInputs(EnergyPlusData &state, bool &ErrorsFound) // IF err
 
     RepVarSet.dimension(state.dataGlobal->NumOfZones, true);
 
-    // Following used for reporting
-    state.dataHeatBal->ZnAirRpt.allocate(state.dataGlobal->NumOfZones);
-    if (state.dataHeatBal->doSpaceHeatBalanceSizing || state.dataHeatBal->doSpaceHeatBalanceSimulation) {
-        state.dataHeatBal->spaceAirRpt.allocate(state.dataGlobal->numSpaces);
-    }
-
     for (int Loop = 1; Loop <= state.dataGlobal->NumOfZones; ++Loop) {
         std::string const &name = state.dataHeatBal->Zone(Loop).Name;
         auto &thisZnAirRpt = state.dataHeatBal->ZnAirRpt(Loop);

--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -2083,15 +2083,10 @@ namespace HeatBalanceManager {
 
         // allocate the array the holds the predefined report data
         state.dataHeatBal->ZonePreDefRep.allocate(state.dataGlobal->NumOfZones);
+        state.dataHeatBal->ZnAirRpt.allocate(state.dataGlobal->NumOfZones);
 
         // Now get Space data after Zones are set up, because Space is optional, Zones are not
         GetSpaceData(state, ErrorsFound);
-
-        // Following used for reporting--moved here to avoid a crash in Kiva that sets up a report variable that uses ZnAirRpt
-        state.dataHeatBal->ZnAirRpt.allocate(state.dataGlobal->NumOfZones);
-        if (state.dataHeatBal->doSpaceHeatBalanceSizing || state.dataHeatBal->doSpaceHeatBalanceSimulation) {
-            state.dataHeatBal->spaceAirRpt.allocate(state.dataGlobal->numSpaces);
-        }
     }
 
     void GetIncidentSolarMultiplier(EnergyPlusData &state, bool &ErrorsFound)

--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -2086,6 +2086,12 @@ namespace HeatBalanceManager {
 
         // Now get Space data after Zones are set up, because Space is optional, Zones are not
         GetSpaceData(state, ErrorsFound);
+
+        // Following used for reporting--moved here to avoid a crash in Kiva that sets up a report variable that uses ZnAirRpt
+        state.dataHeatBal->ZnAirRpt.allocate(state.dataGlobal->NumOfZones);
+        if (state.dataHeatBal->doSpaceHeatBalanceSizing || state.dataHeatBal->doSpaceHeatBalanceSimulation) {
+            state.dataHeatBal->spaceAirRpt.allocate(state.dataGlobal->numSpaces);
+        }
     }
 
     void GetIncidentSolarMultiplier(EnergyPlusData &state, bool &ErrorsFound)

--- a/tst/EnergyPlus/unit/HeatBalanceKivaManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceKivaManager.unit.cc
@@ -559,6 +559,16 @@ TEST_F(EnergyPlusFixture, HeatBalanceKiva_setupKivaInstances_ThermalComfort)
         "  ThermostatSetpoint:DualSetpoint,  !- Control 1 Object Type",
         "  Core_bottom DualSPSched; !- Control 1 Name",
         " ",
+        "ZoneControl:Thermostat:OperativeTemperature,",
+        "  Core_bottom Thermostat,  !- Thermostat Name",
+        "  Constant,                !- Radiative Fraction Input Mode",
+        "  0.4;                     !- Fixed Radiative Fraction",
+        " ",
+        "Output:Variable,",
+        "  *,                       !- Key Value",
+        "  Zone Thermostat Operative Temperature,  !- Variable Name",
+        "  Hourly;                  !- Reporting Frequency",
+        " ",
         "ZoneControl:Thermostat:ThermalComfort,",
         "  Core_bottom Comfort,     !- Name",
         "  Core_bottom,             !- Zone or ZoneList Name",
@@ -709,6 +719,8 @@ TEST_F(EnergyPlusFixture, HeatBalanceKiva_setupKivaInstances_ThermalComfort)
     state->dataGlobal->TimeStep = 1;          // must initialize this to get schedules initialized
 
     state->files.inputWeatherFilePath.filePath = configured_source_directory() / "tst/EnergyPlus/unit/Resources/HeatBalanceKivaManagerOSkyTest.epw";
+    state->dataWeather->WeatherFileExists = true;
+    state->dataHeatBal->AnyKiva = true; // Exercise Kiva's early thermostat-input path
     HeatBalanceManager::GetHeatBalanceInput(*state);
     EXPECT_FALSE(has_err_output());
 }

--- a/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceManager.unit.cc
@@ -2465,6 +2465,58 @@ TEST_F(EnergyPlusFixture, HeatBalanceManager_EMSMaterialThermalAbsorptanceUpdate
     EXPECT_EQ(construction.OutsideAbsorpThermal, emsThermalAbsorptance);
 }
 
+TEST_F(EnergyPlusFixture, GetZoneDataTest)
+{
+    // Testing of fix for bug #11733
+    std::string const idf_objects = delimited_string({
+        "  Zone,",
+        "    Shire,            !- Name",
+        "    0,                !- Direction of Relative North {deg}",
+        "    0,                !- X Origin {m}",
+        "    0,                !- Y Origin {m}",
+        "    0,                !- Z Origin {m}",
+        "    1,                !- Type",
+        "    1,                !- Multiplier",
+        "    2.5,              !- Ceiling Height {m}",
+        "    100.0;            !- Volume {m3}",
+
+        "  Zone,",
+        "    Rivendell,        !- Name",
+        "    0,                !- Direction of Relative North {deg}",
+        "    0,                !- X Origin {m}",
+        "    0,                !- Y Origin {m}",
+        "    0,                !- Z Origin {m}",
+        "    1,                !- Type",
+        "    2,                !- Multiplier",
+        "    3.0,              !- Ceiling Height {m}",
+        "    150.0;            !- Volume {m3}",
+
+        "  Zone,",
+        "    Gondor,           !- Name",
+        "    0,                !- Direction of Relative North {deg}",
+        "    0,                !- X Origin {m}",
+        "    0,                !- Y Origin {m}",
+        "    0,                !- Z Origin {m}",
+        "    1,                !- Type",
+        "    1,                !- Multiplier",
+        "    4.0,              !- Ceiling Height {m}",
+        "    200.0;            !- Volume {m3}",
+    });
+
+    bool errorsFound = false;
+
+    ASSERT_TRUE(process_idf(idf_objects));
+    state->init_state(*state);
+
+    GetZoneData(*state, errorsFound);
+    EXPECT_FALSE(errorsFound);
+    EXPECT_EQ("SHIRE", state->dataHeatBal->Zone(1).Name);
+    EXPECT_EQ("RIVENDELL", state->dataHeatBal->Zone(2).Name);
+    EXPECT_EQ("GONDOR", state->dataHeatBal->Zone(3).Name);
+    EXPECT_EQ(size_t(3), state->dataHeatBal->ZonePreDefRep.size());
+    EXPECT_EQ(size_t(3), state->dataHeatBal->ZnAirRpt.size());
+}
+
 TEST_F(EnergyPlusFixture, HeatBalanceManager_GetSpaceData)
 {
     // Test input processing of Space object


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11733

### Description of the purpose of this PR

When a user chooses to use operative temperature controls within an EnergyPlus simulation that also uses Kiva and requests the Zone Thermostat Operative Temperature output variable, a hard crash ensues because the ZnAirRpt array has not yet been allocated.  This was happening in GetSimpleAirModelInputs, but this was after Kiva and also after the Zone Operative Temperature variable was set-up.  So, the allocation of this array was moved up.  Since it is only dependent on the number of zones and there was already another report variable like it that was based on the number of zones, the allocation statement was moved to that location at the end of GetZoneData where it more logically fits given the size of the array.  Once this was done, the input file that was crashing successfully ran to completion.  No diffs were noted in the test suite and none were expected.  A new fairly simple unit test to ensure that this array is being size in GetZoneData was added.  No changes to the documentation or the idf files was needed.

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [X] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [X] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [X] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
