### PR TITLE
Fix #11773 - ShowRecurringXXXAtEnd and SummarizeErrors is terribly inefficient 

### DIFF
--- a/.github/workflows/test_develop_commits.yml
+++ b/.github/workflows/test_develop_commits.yml
@@ -29,7 +29,7 @@ jobs:
 #          nproc: 3
 #          pretty: "Standard Build on Mac x64"
 #          alternate: false
-#          build-type: release
+#          build-type: Release
 #          run-tests: true
         - os: macos-14
           macos_dev_target: 14.0
@@ -39,7 +39,7 @@ jobs:
           nproc: 3
           pretty: "Standard Build on Mac arm64"
           alternate: false
-          build-type: release
+          build-type: Release
           run-tests: true
           link-with-python: true
 #        - os: ubuntu-24.04
@@ -49,7 +49,7 @@ jobs:
 #          nproc: 4
 #          pretty: "Standard Build on Ubuntu 24.04"
 #          alternate: false
-#          build-type: release
+#          build-type: Release
 #          run-tests: true
 #          link-with-python: true
         - os: windows-2022
@@ -59,7 +59,7 @@ jobs:
           nproc: 4
           pretty: "Standard Build on Windows VS 2022 - Debug"
           alternate: false
-          build-type: debug
+          build-type: Debug
           run-tests: false
           link-with-python: true
         - os: windows-2022
@@ -69,7 +69,7 @@ jobs:
           nproc: 4
           pretty: "Standard Build on Windows VS 2022 - Debug, No Python"
           alternate: false
-          build-type: debug
+          build-type: Debug
           run-tests: false
           link-with-python: false
         - os: ubuntu-24.04
@@ -79,7 +79,7 @@ jobs:
           nproc: 4
           pretty: "Alternate Build on Ubuntu 24.04"
           alternate: true
-          build-type: release
+          build-type: Release
           run-tests: false
           link-with-python: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -182,6 +182,14 @@ repos:
     pass_filenames: true
     require_serial: true
 
+  - id: check-error-summary-increment
+    name: check DataErrorTracking ErrorSummaryType increments
+    entry: python scripts/dev/check_error_summary_increment.py
+    args: ['--verbose']
+    language: python
+    files: '^src/EnergyPlus/.*\.(cc|hh)$'
+    pass_filenames: false
+
   # This was taking 1min20 before, and 14s with parallel on my 16-thread machine but it's still too slow for a pre-commit hook, so manual only
   # Run it with: pre-commit run --hook-stage manual check-for-enum-scope-usage --verbose --all-files
   - id: check-for-enum-scope-usage

--- a/scripts/dev/check_error_summary_increment.py
+++ b/scripts/dev/check_error_summary_increment.py
@@ -1,0 +1,472 @@
+# EnergyPlus, Copyright (c) 1996-present, The Board of Trustees of the
+# University of Illinois, The Regents of the University of California, through
+# Lawrence Berkeley National Laboratory (subject to receipt of any required
+# approvals from the U.S. Dept. of Energy), Oak Ridge National Laboratory,
+# managed by UT-Battelle, Alliance for Energy Innovation, LLC, and other
+# contributors. All rights reserved.
+#
+# NOTICE: This Software was developed under funding from the U.S. Department of
+# Energy and the U.S. Government consequently retains certain rights. As such,
+# the U.S. Government has been granted for itself and others acting on its
+# behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
+# Software to reproduce, distribute copies to the public, prepare derivative
+# works, and perform publicly and display publicly, and to permit others to do
+# so.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# (1) Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+# (2) Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+# (3) Neither the name of the University of California, Lawrence Berkeley
+#     National Laboratory, the University of Illinois, U.S. Dept. of Energy nor
+#     the names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# (4) Use of EnergyPlus(TM) Name. If Licensee (i) distributes the software in
+#     stand-alone form without changes from the version obtained under this
+#     License, or (ii) Licensee makes a reference solely to the software
+#     portion of its product, Licensee must refer to the software as
+#     "EnergyPlus version X" software, where "X" is the version number Licensee
+#     obtained under this License and may not use a different name for the
+#     software. Except as specifically required in this Section (4), Licensee
+#     shall not use in a company name, a product name, in advertising,
+#     publicity, or other promotional activities any name, trade name,
+#     trademark, logo, or other designation of "EnergyPlus", "E+", "e+" or
+#     confusingly similar designation, without the U.S. Department of Energy's
+#     prior written consent.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Check that DataErrorTracking::ErrorSummaryType stays in sync with its call sites.
+
+- DataErrorTracking.hh's enum entries carry a short truncated "search string" in a
+  trailing comment (eg `// "Node Connection Error"`). That string is a verbatim substring
+  of the actual ShowXXX() message printed at the real point of call - it predates this
+  refactor (it used to be used to scan the whole error file for these strings) and is now
+  repurposed purely as a lookup key for this script.
+- UtilityRoutines.cc's `ErrorSummaries` array must have one entry per enum value (Num
+  excluded), in the same order, each starting with `// EnumName` followed by a
+  `{"Summary", "MoreDetails"}` entry. That .Summary text is what gets printed in the
+  "Final Error Summary"; it is not expected to match the call site's message.
+- Every "live" entry must have, somewhere in the .cc sources, a
+  `++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::X)];`
+  near a ShowXXX() call whose message contains X's search string (order between the two
+  varies, and there's sometimes a block of unrelated ShowContinueError() calls in between).
+- An enum entry with no such increment anywhere is dead: it should be removed from both
+  the enum (DataErrorTracking.hh) and the ErrorSummaries array (UtilityRoutines.cc).
+- A ShowXXX() call whose message contains a search string but has no matching increment
+  nearby is suspicious: either the increment was forgotten, or the search string is
+  stale/coincidental.
+"""
+
+import re
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+from base_hook import (
+    SRC_DIR,
+    ErrorMessage,
+    LogLevel,
+    LogMessage,
+    WarningMessage,
+    collect_files,
+    exit_hook,
+    flatten_list_of_lists,
+    get_base_parser,
+    parallel_apply,
+    report_log_messages,
+)
+
+DATA_ERROR_TRACKING_HH = SRC_DIR / "DataErrorTracking.hh"
+UTILITY_ROUTINES_CC = SRC_DIR / "UtilityRoutines.cc"
+
+ENUM_ENTRY_RE = re.compile(r"^\s*(\w+)\s*(?:=\s*\d+)?\s*,?\s*(?://\s*\"([^\"]*)\")?\s*$")
+
+SUMMARIES_ENTRY_RE = re.compile(r"//\s*(\w+)\s*\n\s*\{\s*\"([^\"]*)\"")
+
+INCREMENT_RE = re.compile(
+    r"\+\+\s*state\s*\.\s*dataErrTracking\s*->\s*ErrorSummaryCount\s*\[\s*static_cast<size_t>\s*\(\s*"
+    r"DataErrorTracking::ErrorSummaryType::(\w+)\s*\)\s*\]\s*;"
+)
+
+SHOW_CALL_RE = re.compile(r"\bShow\w*\s*\(")
+
+STRIP_RE = re.compile(r'"(?:\\.|[^"\\])*"|/\*.*?\*/|//[^\n]*', re.DOTALL)
+
+# How far apart (in characters, either direction) an ErrorSummaryCount increment and the
+# ShowXXX() call it belongs to are allowed to be. Generous because a call is sometimes
+# followed by a block of unrelated ShowContinueError() diagnostics before a final
+# ShowRecurringXXXErrorAtEnd() call that repeats the same search string, and the
+# increment itself sometimes precedes and sometimes follows the call.
+WINDOW_CHARS = 4000
+
+
+def strip_comments(text: str) -> str:
+    """Blank out // and /* */ comments (keeping length and newlines) so they can't produce
+    matches; string literals are left untouched."""
+
+    def _replace(m: re.Match) -> str:
+        matched = m.group(0)
+        if matched.startswith('"'):
+            return matched
+        return "".join(c if c == "\n" else " " for c in matched)
+
+    return STRIP_RE.sub(_replace, text)
+
+
+@dataclass
+class EnumEntry:
+    name: str
+    line_number: int
+    search_string: str | None
+
+
+@dataclass
+class SummaryEntry:
+    name: str
+    summary: str
+
+
+@dataclass
+class IncrementSite:
+    enum_name: str
+    line_number: int
+    matched: bool  # whether a nearby ShowXXX() call was found containing the search string
+
+
+def line_of(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def parse_enum_entries(hh_path: Path) -> list[EnumEntry]:
+    """Parse the ErrorSummaryType enum (name, line number, and trailing "search string" comment)."""
+    text = hh_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    start_idx = next(i for i, line in enumerate(lines) if "enum class ErrorSummaryType" in line)
+    brace_idx = next(i for i in range(start_idx, len(lines)) if "{" in lines[i])
+
+    entries: list[EnumEntry] = []
+    for i in range(brace_idx + 1, len(lines)):
+        line = lines[i]
+        if "}" in line:
+            break
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//"):
+            continue
+        m = ENUM_ENTRY_RE.match(line)
+        if not m:
+            raise ValueError(f"{hh_path}:{i + 1}: could not parse enum entry: {line!r}")
+        name = m.group(1)
+        if name == "Num":
+            continue
+        entries.append(EnumEntry(name=name, line_number=i + 1, search_string=m.group(2)))
+    return entries
+
+
+def parse_error_summaries(cc_path: Path) -> list[SummaryEntry]:
+    """Parse the `// EnumName` / `{"Summary", ...}` entries of the ErrorSummaries array."""
+    text = cc_path.read_text(encoding="utf-8")
+    start = text.index("ErrorSummaries{{")
+    end = text.index("}};", start)
+    block = text[start:end]
+    return [SummaryEntry(name=name, summary=summary) for name, summary in SUMMARIES_ENTRY_RE.findall(block)]
+
+
+def find_show_call_spans(text: str) -> list[tuple[int, int]]:
+    """Return (start, end) spans of every ShowXXX(...) call in `text`, end being just past
+    the call's closing paren (found by paren-balancing from the opening one)."""
+    spans: list[tuple[int, int]] = []
+    for m in SHOW_CALL_RE.finditer(text):
+        depth = 1
+        pos = m.end()
+        end = len(text)
+        while pos < len(text):
+            c = text[pos]
+            if c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    end = pos + 1
+                    break
+            pos += 1
+        spans.append((m.start(), end))
+    return spans
+
+
+def find_key_occurrences(text: str, search_string: str, show_call_spans: list[tuple[int, int]]) -> list[int]:
+    """Return start indices of `search_string` occurrences that sit inside one of `show_call_spans`
+    (ie really are part of a ShowXXX(...) message, not some unrelated string literal)."""
+    occurrences: list[int] = []
+    for call_start, call_end in show_call_spans:
+        idx = text.find(search_string, call_start, call_end)
+        if idx != -1:
+            occurrences.append(idx)
+    return occurrences
+
+
+def check_text(
+    raw_text: str, filepath: Path, enum_entries_by_name: dict[str, EnumEntry]
+) -> tuple[list[IncrementSite], list[LogMessage]]:
+    """Scan one .cc file's text: collect every ErrorSummaryCount increment, and flag ShowXXX
+    calls whose message contains a search string with no ErrorSummaryCount increment nearby
+    (or vice versa). Proximity is checked in both directions since the increment sometimes
+    precedes and sometimes follows the ShowXXX() call it belongs to."""
+    text = strip_comments(raw_text)
+    log_messages: list[LogMessage] = []
+    sites: list[IncrementSite] = []
+
+    increment_spans = list(INCREMENT_RE.finditer(text))
+    show_call_spans = find_show_call_spans(text)
+    key_occurrences_by_name = {
+        entry.name: find_key_occurrences(text, entry.search_string, show_call_spans)
+        for entry in enum_entries_by_name.values()
+        if entry.search_string is not None
+    }
+
+    for m in increment_spans:
+        enum_name = m.group(1)
+        entry = enum_entries_by_name.get(enum_name)
+        matched = False
+        if entry is not None and entry.search_string is not None:
+            matched = any(abs(occ - m.start()) <= WINDOW_CHARS for occ in key_occurrences_by_name.get(enum_name, []))
+        sites.append(IncrementSite(enum_name=enum_name, line_number=line_of(text, m.start()), matched=matched))
+        if entry is not None and entry.search_string is not None and not matched:
+            log_messages.append(
+                WarningMessage(
+                    tool="check_error_summary_increment",
+                    filepath=filepath,
+                    line_number=line_of(text, m.start()),
+                    line=raw_text.splitlines()[line_of(text, m.start()) - 1].strip(),
+                    message=(
+                        f"++ErrorSummaryCount[...ErrorSummaryType::{enum_name}] has no nearby ShowXXX() call containing "
+                        f"the expected search string {entry.search_string!r} (see DataErrorTracking.hh:{entry.line_number})"
+                    ),
+                )
+            )
+
+    # Reverse direction: a ShowXXX() call containing a search string with no matching
+    # increment nearby likely means the increment was forgotten.
+    increment_positions_by_name: dict[str, list[int]] = {}
+    for m in increment_spans:
+        increment_positions_by_name.setdefault(m.group(1), []).append(m.start())
+
+    for enum_name, occurrences in key_occurrences_by_name.items():
+        entry = enum_entries_by_name[enum_name]
+        increment_positions = increment_positions_by_name.get(enum_name, [])
+        for occ in occurrences:
+            if any(abs(occ - pos) <= WINDOW_CHARS for pos in increment_positions):
+                continue
+            log_messages.append(
+                WarningMessage(
+                    tool="check_error_summary_increment",
+                    filepath=filepath,
+                    line_number=line_of(text, occ),
+                    line=raw_text.splitlines()[line_of(text, occ) - 1].strip(),
+                    message=(
+                        f"ShowXXX() call contains {entry.search_string!r}, the search string for "
+                        f"ErrorSummaryType::{enum_name} (see DataErrorTracking.hh:{entry.line_number}), "
+                        "but has no ++ErrorSummaryCount[...] increment nearby - forgot to add it?"
+                    ),
+                )
+            )
+
+    return sites, log_messages
+
+
+def check_file(
+    filepath: Path, enum_entries_by_name: dict[str, EnumEntry]
+) -> tuple[list[IncrementSite], list[LogMessage]]:
+    """Read and scan a single .cc file. See `check_text` for the actual logic."""
+    return check_text(filepath.read_text(encoding="utf-8"), filepath, enum_entries_by_name)
+
+
+class TestCheckErrorSummaryIncrement(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dummy_file = Path("DummyFile.cc")
+        # Two enum entries, both with a search string.
+        self.enum_entries_by_name = {
+            "FooError": EnumEntry(name="FooError", line_number=10, search_string="Foo happened"),
+            "BarError": EnumEntry(name="BarError", line_number=11, search_string="Bar happened"),
+        }
+
+    def test_valid_increment_immediately_before_call(self) -> None:
+        text = """
+        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::FooError)];
+        ShowSevereError(state, "Foo happened here");
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(len(sites), 1)
+        self.assertTrue(sites[0].matched)
+        self.assertEqual(log_messages, [])
+
+    def test_valid_increment_after_call(self) -> None:
+        # The increment comes after the ShowXXX() call it belongs to (eg SimulationManager.cc's
+        # NodeConnectionErrors), which must be accepted just like the more common order.
+        text = """
+        ShowWarningError(state, std::format("Foo happened for object {}", CType));
+        ShowContinueError(state, "some detail");
+        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::FooError)];
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(len(sites), 1)
+        self.assertTrue(sites[0].matched)
+        self.assertEqual(log_messages, [])
+
+    def test_valid_increment_several_lines_above(self) -> None:
+        # A ShowSevereMessage() followed by several unrelated ShowContinueError() diagnostics
+        # before a final ShowRecurringSevereErrorAtEnd() that repeats the search string (eg
+        # HeatBalanceSurfaceManager.cc's TemperatureLowOutOfBounds) must not be flagged.
+        filler = "\n".join(f'ShowContinueError(state, "...filler detail {i}");' for i in range(20))
+        text = f"""
+        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::FooError)];
+        ShowSevereMessage(state, "Foo happened here");
+        {filler}
+        ShowRecurringSevereErrorAtEnd(state, "Foo happened for zone=X", count, low, high, _, "C", "C");
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(len(sites), 1)
+        self.assertTrue(sites[0].matched)
+        self.assertEqual(log_messages, [])
+
+    def test_dead_entry_has_no_increment_site(self) -> None:
+        # BarError's search string never shows up at all: check_text should report neither
+        # an increment site nor a missing-increment warning for it - dead-entry detection
+        # itself happens one level up, across all files, once no site is found anywhere.
+        text = """
+        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::FooError)];
+        ShowSevereError(state, "Foo happened here");
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual({s.enum_name for s in sites}, {"FooError"})
+        self.assertEqual(log_messages, [])
+
+    def test_call_without_nearby_increment_is_flagged(self) -> None:
+        text = """
+        ShowWarningError(state, "Bar happened but the counter was forgotten");
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(sites, [])
+        self.assertEqual(len(log_messages), 1)
+        self.assertIn("BarError", log_messages[0].message)
+        self.assertIn("forgot to add it", log_messages[0].message)
+
+    def test_increment_without_nearby_call_is_flagged(self) -> None:
+        text = """
+        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::FooError)];
+        // the ShowXXX() call was removed but the increment was left behind
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(len(sites), 1)
+        self.assertFalse(sites[0].matched)
+        self.assertEqual(len(log_messages), 1)
+        self.assertIn("has no nearby ShowXXX() call", log_messages[0].message)
+
+    def test_search_string_outside_a_show_call_is_ignored(self) -> None:
+        # A plain string literal that happens to contain the search string (eg an object
+        # name in an array) must not count as a call site.
+        text = """
+        Array1D_string const cMaterialGroupType({"Foo happened elsewhere, not in a Show call"});
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(sites, [])
+        self.assertEqual(log_messages, [])
+
+    def test_commented_out_call_is_ignored(self) -> None:
+        text = """
+        // CALL ShowFatalError('Foo happened, node=' // NodeName // &
+        // ', check for details in the following messages.')
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(sites, [])
+        self.assertEqual(log_messages, [])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "test":
+        del sys.argv[1:]
+        unittest.main(exit=True, verbosity=0)
+
+    parser = get_base_parser(
+        description="Check DataErrorTracking::ErrorSummaryType entries against their ErrorSummaryCount call sites",
+        include_files_arg=False,
+    )
+    args = parser.parse_args()
+
+    enum_entries = parse_enum_entries(DATA_ERROR_TRACKING_HH)
+    enum_entries_by_name = {e.name: e for e in enum_entries}
+    summary_entries = parse_error_summaries(UTILITY_ROUTINES_CC)
+
+    log_messages: list[LogMessage] = []
+
+    # Sanity check: the ErrorSummaries array must mirror the enum, in order.
+    enum_names = [e.name for e in enum_entries]
+    summary_names = [s.name for s in summary_entries]
+    if enum_names != summary_names:
+        log_messages.append(
+            ErrorMessage(
+                tool="check_error_summary_increment",
+                filepath=UTILITY_ROUTINES_CC,
+                message=(
+                    "ErrorSummaries array order/contents does not match the ErrorSummaryType enum.\n"
+                    f"  enum:     {enum_names}\n"
+                    f"  array:    {summary_names}"
+                ),
+            )
+        )
+
+    for entry in enum_entries:
+        if entry.search_string is None:
+            log_messages.append(
+                ErrorMessage(
+                    tool="check_error_summary_increment",
+                    filepath=DATA_ERROR_TRACKING_HH,
+                    line_number=entry.line_number,
+                    message=f'ErrorSummaryType::{entry.name} has no trailing `// "search string"` comment to check it against',
+                )
+            )
+
+    files = list(collect_files(base_dir=SRC_DIR, extensions={".cc"}, recursive=True, dirs_to_skip=[]))
+    if args.verbose:
+        print(f"Checking {len(files)} .cc files under {SRC_DIR}")
+
+    results = parallel_apply(func=check_file, filepaths=files, enum_entries_by_name=enum_entries_by_name)
+    all_sites: list[IncrementSite] = flatten_list_of_lists([sites for sites, _ in results])
+    log_messages += flatten_list_of_lists([msgs for _, msgs in results])
+
+    live_enum_names = {site.enum_name for site in all_sites}
+    for entry in enum_entries:
+        if entry.name not in live_enum_names:
+            log_messages.append(
+                ErrorMessage(
+                    tool="check_error_summary_increment",
+                    filepath=DATA_ERROR_TRACKING_HH,
+                    line_number=entry.line_number,
+                    message=(
+                        f"ErrorSummaryType::{entry.name} has no ++ErrorSummaryCount[...] call site anywhere under {SRC_DIR}; "
+                        "it is dead and should be removed from the ErrorSummaryType enum and the ErrorSummaries array"
+                    ),
+                )
+            )
+
+    success = report_log_messages(log_messages=log_messages, fail_threshold=LogLevel.ERROR, verbose=args.verbose)
+    exit_hook(success=success)

--- a/scripts/dev/check_error_summary_increment.py
+++ b/scripts/dev/check_error_summary_increment.py
@@ -86,7 +86,6 @@ from base_hook import (
     ErrorMessage,
     LogLevel,
     LogMessage,
-    WarningMessage,
     collect_files,
     exit_hook,
     flatten_list_of_lists,
@@ -252,7 +251,7 @@ def check_text(
         sites.append(IncrementSite(enum_name=enum_name, line_number=line_of(text, m.start()), matched=matched))
         if entry is not None and entry.search_string is not None and not matched:
             log_messages.append(
-                WarningMessage(
+                ErrorMessage(
                     tool="check_error_summary_increment",
                     filepath=filepath,
                     line_number=line_of(text, m.start()),
@@ -277,7 +276,7 @@ def check_text(
             if any(abs(occ - pos) <= WINDOW_CHARS for pos in increment_positions):
                 continue
             log_messages.append(
-                WarningMessage(
+                ErrorMessage(
                     tool="check_error_summary_increment",
                     filepath=filepath,
                     line_number=line_of(text, occ),
@@ -367,6 +366,7 @@ class TestCheckErrorSummaryIncrement(unittest.TestCase):
         sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
         self.assertEqual(sites, [])
         self.assertEqual(len(log_messages), 1)
+        self.assertEqual(log_messages[0].loglevel, LogLevel.ERROR)
         self.assertIn("BarError", log_messages[0].message)
         self.assertIn("forgot to add it", log_messages[0].message)
 
@@ -379,7 +379,29 @@ class TestCheckErrorSummaryIncrement(unittest.TestCase):
         self.assertEqual(len(sites), 1)
         self.assertFalse(sites[0].matched)
         self.assertEqual(len(log_messages), 1)
+        self.assertEqual(log_messages[0].loglevel, LogLevel.ERROR)
         self.assertIn("has no nearby ShowXXX() call", log_messages[0].message)
+
+    def test_wrong_enum_used_is_flagged(self) -> None:
+        # The increment uses FooError, but the ShowXXX() call right next to it is actually
+        # BarError's message - a copy/paste mistake picking the wrong enum value. This must
+        # surface as two separate Errors: FooError's increment has no matching call nearby,
+        # and BarError's call has no matching increment nearby - both real, silent counting bugs.
+        text = """
+        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::FooError)];
+        ShowSevereError(state, "Bar happened here, not Foo");
+        """
+        sites, log_messages = check_text(text, self.dummy_file, self.enum_entries_by_name)
+        self.assertEqual(len(sites), 1)
+        self.assertEqual(sites[0].enum_name, "FooError")
+        self.assertFalse(sites[0].matched)
+
+        self.assertEqual(len(log_messages), 2)
+        self.assertTrue(all(msg.loglevel == LogLevel.ERROR for msg in log_messages))
+        foo_msg = next(msg for msg in log_messages if "FooError" in msg.message)
+        self.assertIn("has no nearby ShowXXX() call", foo_msg.message)
+        bar_msg = next(msg for msg in log_messages if "BarError" in msg.message)
+        self.assertIn("forgot to add it", bar_msg.message)
 
     def test_search_string_outside_a_show_call_is_ignored(self) -> None:
         # A plain string literal that happens to contain the search string (eg an object

--- a/scripts/dev/check_for_malformed_enums.py
+++ b/scripts/dev/check_for_malformed_enums.py
@@ -140,6 +140,7 @@ def process_enum_str(input_str: str, filepath: Path, line_no: int) -> list[LogMe
             "DataHeatBalance.hh:PERptVars",
             "EconomicTariff.hh:StepType",
             "LowTempRadiantSystem.hh:OpMode",
+            "DataErrorTracking.hh:ErrorSummaryType",
         ]
         if f"{file_name}:{name}" not in exceptions:
             log_messages.append(

--- a/src/EnergyPlus/AirLoopHVACDOAS.cc
+++ b/src/EnergyPlus/AirLoopHVACDOAS.cc
@@ -57,6 +57,7 @@
 #include <EnergyPlus/DataAirLoop.hh>
 #include <EnergyPlus/DataAirSystems.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataLoopNode.hh>
 #include <EnergyPlus/DataSizing.hh>
 #include <EnergyPlus/DesiccantDehumidifiers.hh>
@@ -623,6 +624,8 @@ namespace AirLoopHVACDOAS {
                                     thisDOAS.m_exhaustFanTypeNum = SimAirServingZones::CompType::Fan_ComponentModel;
                                 }
                             } else {
+                                ++state.dataErrTracking
+                                      ->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
                                 ShowSevereError(
                                     state,
                                     std::format("getAirLoopMixer: Node Connection Error in AirLoopHVAC:DedicatedOutdoorAirSystem = {}. Inlet node "

--- a/src/EnergyPlus/BranchNodeConnections.cc
+++ b/src/EnergyPlus/BranchNodeConnections.cc
@@ -57,6 +57,7 @@
 #include <EnergyPlus/BranchNodeConnections.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataBranchNodeConnections.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataLoopNode.hh>
 #include <EnergyPlus/NodeInputManager.hh>
 #include <EnergyPlus/UtilityRoutines.hh>
@@ -934,6 +935,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = true;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(
                 state,
                 std::format("Node Connection Error, Node=\"{}\", Sensor node did not find a matching node of appropriate type (other than "
@@ -973,6 +975,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = true;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(
                 state,
                 std::format("Node Connection Error, Node=\"{}\", Actuator node did not find a matching node of appropriate type (other than "
@@ -1019,6 +1022,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = true;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(
                 state,
                 std::format("Node Connection Error, Node=\"{}\", Setpoint node did not find a matching node of appropriate type (other than "
@@ -1034,6 +1038,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             ErrorsFound = true;
         }
         if (!IsInlet && !IsOutlet) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(state,
                             std::format("Node Connection Error, Node=\"{}\", Setpoint node did not find a matching node of type Inlet or Outlet.",
                                         state.dataBranchNodeConnections->NodeConnections(Loop1).NodeName));
@@ -1070,6 +1075,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = true;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(state,
                             std::format("Node Connection Error, Node=\"{}\", ZoneInlet node did not find an outlet node.",
                                         state.dataBranchNodeConnections->NodeConnections(Loop1).NodeName));
@@ -1103,6 +1109,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = true;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(state,
                             std::format("Node Connection Error, Node=\"{}\", ZoneExhaust node did not find a matching inlet node.",
                                         state.dataBranchNodeConnections->NodeConnections(Loop1).NodeName));
@@ -1136,6 +1143,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = true;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(
                 state,
                 std::format("Node Connection Error, Node=\"{}\", Return plenum induced air outlet node did not find a matching inlet node.",
@@ -1195,6 +1203,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             IsValid = false;
         }
         if (!IsValid && !MatchedAtLeastOne) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(state,
                             std::format("{}{}{}",
                                         "Node Connection Error, Node=\"",
@@ -1232,6 +1241,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             }
             if (state.dataBranchNodeConnections->NodeConnections(Loop2).NodeNumber ==
                 state.dataBranchNodeConnections->NodeConnections(Loop1).NodeNumber) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
                 ShowSevereError(state,
                                 std::format("Node Connection Error, Node=\"{}\", The same node appears as a non-parent Inlet node more than once.",
                                             state.dataBranchNodeConnections->NodeConnections(Loop1).NodeName));
@@ -1276,6 +1286,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             if (state.dataBranchNodeConnections->NodeConnections(Loop2).NodeNumber ==
                 state.dataBranchNodeConnections->NodeConnections(Loop1).NodeNumber) {
                 // Skip if one of the
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
                 ShowSevereError(state,
                                 std::format("Node Connection Error, Node=\"{}\", The same node appears as a non-parent Outlet node more than once.",
                                             state.dataBranchNodeConnections->NodeConnections(Loop1).NodeName));
@@ -1319,6 +1330,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             break;
         }
         if (!IsValid) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             ShowSevereError(state,
                             std::format("{}{}{}",
                                         "Node Connection Error, Node=\"",
@@ -1402,6 +1414,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
             }
             if (!IsValid) {
 
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
                 ShowSevereError(
                     state,
                     std::format("(Developer) Node Connection Error, Object={}:{}",
@@ -1443,6 +1456,7 @@ void CheckNodeConnections(EnergyPlusData &state, bool &ErrorsFound)
                     continue;
                 }
 
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
                 ShowSevereError(state,
                                 std::format("Node Connection Error, Node Name=\"{}\", The same zone node appears more than once.",
                                             state.dataBranchNodeConnections->NodeConnections(Loop1).NodeName));

--- a/src/EnergyPlus/CMakeLists.txt
+++ b/src/EnergyPlus/CMakeLists.txt
@@ -789,6 +789,11 @@ if(DEBUG_PYTHON_CONFIG)
   target_compile_definitions(energypluslib PUBLIC DEBUG_PYTHON_CONFIG=1)
 endif()
 
+# Detect incorrect recurring error MsgIndex usage (throw on every recurring error call). Always on for Debug configs.
+option(FORCE_DEBUG_MSG_INDEX "Force-enable detection of incorrect recurring error MsgIndex usage in non Debug mode" OFF)
+mark_as_advanced(FORCE_DEBUG_MSG_INDEX)
+target_compile_definitions(energypluslib PUBLIC $<$<OR:$<CONFIG:Debug>,$<BOOL:${FORCE_DEBUG_MSG_INDEX}>>:DEBUG_MSG_INDEX>)
+
 if(ENABLE_UNITY)
   set_target_properties(energypluslib PROPERTIES UNITY_BUILD ON)
 endif()

--- a/src/EnergyPlus/DXCoils.cc
+++ b/src/EnergyPlus/DXCoils.cc
@@ -13430,8 +13430,8 @@ void CalcMultiSpeedDXCoilCooling(EnergyPlusData &state,
                                 "at speed {} error continues...",
                                 HVAC::coilTypeNames[(int)thisDXCoil.coilType],
                                 thisDXCoil.Name,
-                                SpeedNumHS),
-                    thisDXCoil.MSErrIndex(SpeedNumHS),
+                                SpeedNum),
+                    thisDXCoil.MSErrIndex(SpeedNum),
                     VolFlowperRatedTotCap,
                     VolFlowperRatedTotCap);
             }
@@ -15117,12 +15117,13 @@ void CalcTwoSpeedDXCoilStandardRating(EnergyPlusData &state, int const DXCoilNum
                 state, thisDXCoil.CCapFTemp2, CoolingCoilInletAirWetBulbTempRated, OutdoorUnitInletAirDryBulbTempPLTestPoint(PartLoadTestPoint));
             //    Warn user if curve output goes negative
             if (TotCapTempModFac < 0.0) {
-                if (thisDXCoil.CCapFTempErrorIndex == 0) {
+                if (thisDXCoil.CCapFTempErrorIndex2 == 0) {
                     ShowWarningMessage(state,
                                        std::format("{}{} \"{}\":", RoutineName, HVAC::coilTypeNames[(int)thisDXCoil.coilType], thisDXCoil.Name));
-                    ShowContinueError(state,
-                                      std::format(" Total Cooling Capacity Modifier curve (function of temperature) output is negative ({:.3f}).",
-                                                  TotCapTempModFac));
+                    ShowContinueError(
+                        state,
+                        std::format(" Total Cooling Capacity Modifier curve (function of temperature), low speed, output is negative ({:.3f}).",
+                                    TotCapTempModFac));
                     ShowContinueError(
                         state,
                         std::format(" Negative value occurs using a coil inlet wet-bulb temperature of {:.1f} and an outdoor unit inlet air "
@@ -15131,16 +15132,15 @@ void CalcTwoSpeedDXCoilStandardRating(EnergyPlusData &state, int const DXCoilNum
                                     OutdoorUnitInletAirDryBulbTempPLTestPoint(PartLoadTestPoint)));
                     ShowContinueErrorTimeStamp(state, " Resetting curve output to zero and continuing simulation.");
                 }
-                ShowRecurringWarningErrorAtEnd(
-                    state,
-                    std::format(
-                        "{}{} \"{}\": Total Cooling Capacity Modifier curve (function of temperature) output is negative warning continues...",
-                        RoutineName,
-                        HVAC::coilTypeNames[(int)thisDXCoil.coilType],
-                        thisDXCoil.Name),
-                    thisDXCoil.CCapFTempErrorIndex,
-                    TotCapTempModFac,
-                    TotCapTempModFac);
+                ShowRecurringWarningErrorAtEnd(state,
+                                               std::format("{}{} \"{}\": Total Cooling Capacity Modifier curve (function of temperature), low "
+                                                           "speed, output is negative warning continues...",
+                                                           RoutineName,
+                                                           HVAC::coilTypeNames[(int)thisDXCoil.coilType],
+                                                           thisDXCoil.Name),
+                                               thisDXCoil.CCapFTempErrorIndex2,
+                                               TotCapTempModFac,
+                                               TotCapTempModFac);
                 TotCapTempModFac = 0.0;
             }
 

--- a/src/EnergyPlus/DXCoils.hh
+++ b/src/EnergyPlus/DXCoils.hh
@@ -143,8 +143,9 @@ namespace DXCoils {
         int AirOutNode;                   // Air outlet node number
         Array1D_int CCapFTemp;            // index of total cooling capacity modifier curve
         // (function of entering wetbulb, outside drybulb)
-        int CCapFTempErrorIndex; // Used for warning messages when output of CCapFTemp is negative
-        Array1D_int CCapFFlow;   // index of total cooling capacity modifier curve
+        int CCapFTempErrorIndex;  // Used for warning messages when output of CCapFTemp is negative
+        int CCapFTempErrorIndex2; // Used for warning messages when output of CCapFTemp2 (low speed, two-speed standard rating calc) is negative
+        Array1D_int CCapFFlow;    // index of total cooling capacity modifier curve
         // (function of actual supply air flow vs rated air flow)
         int CCapFFlowErrorIndex; // Used for warning messages when output of CCapFFlow is negative
         Array1D_int EIRFTemp;    // index of energy input ratio modifier curve
@@ -465,13 +466,13 @@ namespace DXCoils {
               RatedAirVolFlowRate(MaxModes, 0.0), RatedAirVolFlowRateEMSOverrideON(MaxModes, false),
               RatedAirVolFlowRateEMSOverrideValue(MaxModes, 0.0), FanPowerPerEvapAirFlowRate(MaxModes, 0.0),
               FanPowerPerEvapAirFlowRate_2023(MaxModes, 0.0), RatedAirMassFlowRate(MaxModes, 0.0), BypassedFlowFrac(MaxModes, 0.0),
-              RatedCBF(MaxModes, 0.0), AirInNode(0), AirOutNode(0), CCapFTemp(MaxModes, 0), CCapFTempErrorIndex(0), CCapFFlow(MaxModes, 0),
-              CCapFFlowErrorIndex(0), EIRFTemp(MaxModes, 0), EIRFTempErrorIndex(0), EIRFFlow(MaxModes, 0), EIRFFlowErrorIndex(0),
-              PLFFPLR(MaxModes, 0), ReportCoolingCoilCrankcasePower(true), CrankcaseHeaterCapacity(0.0), CrankcaseHeaterPower(0.0),
-              MaxOATCrankcaseHeater(0.0), CrankcaseHeaterCapacityCurveIndex(0), CrankcaseHeaterConsumption(0.0), BasinHeaterPowerFTempDiff(0.0),
-              BasinHeaterSetPointTemp(0.0), CompanionUpstreamDXCoil(0), FindCompanionUpStreamCoil(true), CondenserInletNodeNum(MaxModes, 0),
-              LowOutletTempIndex(0), FullLoadOutAirTempLast(0.0), FullLoadInletAirTempLast(0.0), PrintLowOutTempMessage(false),
-              HeatingCoilPLFCurvePTR(0), RatedTotCap2(0.0), RatedSHR2(0.0), RatedCOP2(0.0), RatedAirVolFlowRate2(0.0),
+              RatedCBF(MaxModes, 0.0), AirInNode(0), AirOutNode(0), CCapFTemp(MaxModes, 0), CCapFTempErrorIndex(0), CCapFTempErrorIndex2(0),
+              CCapFFlow(MaxModes, 0), CCapFFlowErrorIndex(0), EIRFTemp(MaxModes, 0), EIRFTempErrorIndex(0), EIRFFlow(MaxModes, 0),
+              EIRFFlowErrorIndex(0), PLFFPLR(MaxModes, 0), ReportCoolingCoilCrankcasePower(true), CrankcaseHeaterCapacity(0.0),
+              CrankcaseHeaterPower(0.0), MaxOATCrankcaseHeater(0.0), CrankcaseHeaterCapacityCurveIndex(0), CrankcaseHeaterConsumption(0.0),
+              BasinHeaterPowerFTempDiff(0.0), BasinHeaterSetPointTemp(0.0), CompanionUpstreamDXCoil(0), FindCompanionUpStreamCoil(true),
+              CondenserInletNodeNum(MaxModes, 0), LowOutletTempIndex(0), FullLoadOutAirTempLast(0.0), FullLoadInletAirTempLast(0.0),
+              PrintLowOutTempMessage(false), HeatingCoilPLFCurvePTR(0), RatedTotCap2(0.0), RatedSHR2(0.0), RatedCOP2(0.0), RatedAirVolFlowRate2(0.0),
               FanPowerPerEvapAirFlowRate_LowSpeed(MaxModes, 0.0), FanPowerPerEvapAirFlowRate_2023_LowSpeed(MaxModes, 0.0), RatedAirMassFlowRate2(0.0),
               RatedCBF2(0.0), CCapFTemp2(0), EIRFTemp2(0), RatedEIR2(0.0), InternalStaticPressureDrop(0.0), RateWithInternalStaticAndFanObject(false),
               SupplyFanIndex(0), supplyFanType(HVAC::FanType::Invalid), RatedEIR(MaxModes, 0.0), InletAirMassFlowRate(0.0),

--- a/src/EnergyPlus/DataErrorTracking.hh
+++ b/src/EnergyPlus/DataErrorTracking.hh
@@ -65,18 +65,12 @@ namespace DataErrorTracking {
     {
         // Enum Entry                      // "Search String" (used as a lookup in scripts/dev/check_error_summary_increment.py)
         InterZoneSurfaceAreaMismatch = 0,  // "InterZone Surface Areas"
-        InterZoneSurfaceDifferentZones,    // "CAUTION -- Interzone"
         NodeConnectionErrors,              // "Node Connection Error"
         InterZoneSurfaceAzimuthMismatch,   // "InterZone Surface Azimu"
         InterZoneSurfaceTiltMismatch,      // "InterZone Surface Tilts"
         NonPlanarSurfaces,                 // "Suspected non-planar"
-        DeprecatedFeaturesOrKeyValues,     // "Deprecated"
-        IncorrectFloorTilt,                // "Floor Tilt="
-        IncorrectRoofCeilingTilt,          // "Roof/Ceiling Tilt="
         IncompleteViewFactors,             // "View factors not"
-        UnbalancedExhaustAirFlow,          // "Unbalanced exhaust air"
         LoadsInitializationDidNotConverge, // "Loads Initialization"
-        DaylightMapPointsNearWindow,       // "CalcDaylightMapPoints:"
         ZoneAirHeatBalanceWarnings,        // "Zone Air Heat Balance"
         OccupantDensityExtremelyHigh,      // "occupant density is ext"
         TemperatureLowOutOfBounds,         // "Temperature (low) out o"

--- a/src/EnergyPlus/DataErrorTracking.hh
+++ b/src/EnergyPlus/DataErrorTracking.hh
@@ -63,6 +63,7 @@ namespace DataErrorTracking {
     // constexpr std::array<ErrorSummaryInfo, static_cast<size_t>(ErrorSummaryType::Num)> ErrorSummaries
     enum class ErrorSummaryType
     {
+        // Enum Entry                      // "Search String" (used as a lookup in scripts/dev/check_error_summary_increment.py)
         InterZoneSurfaceAreaMismatch = 0,  // "InterZone Surface Areas"
         InterZoneSurfaceDifferentZones,    // "CAUTION -- Interzone"
         NodeConnectionErrors,              // "Node Connection Error"

--- a/src/EnergyPlus/DataErrorTracking.hh
+++ b/src/EnergyPlus/DataErrorTracking.hh
@@ -59,128 +59,32 @@ namespace EnergyPlus {
 
 namespace DataErrorTracking {
 
-    int constexpr SearchCounts(20);
-
-    std::array<const char *, 21> constexpr MessageSearch({"",
-                                                          "InterZone Surface Areas",
-                                                          "CAUTION -- Interzone",
-                                                          "Node Connection Error",
-                                                          "InterZone Surface Azimu",
-                                                          "InterZone Surface Tilts",
-                                                          "Suspected non-planar",
-                                                          "Deprecated",
-                                                          "Floor Tilt=",
-                                                          "Roof/Ceiling Tilt=",
-                                                          "View factors not",
-                                                          "Unbalanced exhaust air",
-                                                          "Loads Initialization",
-                                                          "CalcDaylightMapPoints:",
-                                                          "Zone Air Heat Balance",
-                                                          "occupant density is ext",
-                                                          "Temperature (low) out o",
-                                                          "Temperature (high) out",
-                                                          "nominally unused",
-                                                          "InfraredTransparent",
-                                                          "No reporting elements"});
-    std::array<const char *, 21> constexpr Summaries({"",
-                                                      "InterZone Surface Areas -- mismatch",
-                                                      "Interzone surfaces - different zones",
-                                                      "Node Connection Errors",
-                                                      "InterZone Surface Azimuths -- mismatch",
-                                                      "InterZone Surface Tilts -- mismatch",
-                                                      "Likely non-planar surfaces",
-                                                      "Deprecated Features or Key Values",
-                                                      "Incorrect Floor Tilt",
-                                                      "Incorrect Roof/Ceiling Tilt",
-                                                      "Incomplete View factors",
-                                                      "Unbalanced exhaust air flow",
-                                                      "Loads Initialization did not Converge",
-                                                      "CalcDaylightMapPoints: Window",
-                                                      "Zone Air Heat Balance Warnings",
-                                                      "Occupant density is extremely high",
-                                                      "Temperature (low) out of bounds",
-                                                      "Temperature (high) out of bounds",
-                                                      "Nominally Unused Constructions",
-                                                      "Material:InfraredTransparent usage",
-                                                      "No Reporting Elements requested"});
-
-    // in below -- simple line end <CR>.  End of Whole message <CRE>
-    auto constexpr MoreDetails_0("");
-    auto constexpr MoreDetails_1(
-        "Area mismatch errors happen when the interzone surface in zone A is<CR>not the same size as it's companion in zone B.<CRE>"); // InterZone
-    // Surface
-    // Areas --
-    // mismatch
-    auto constexpr MoreDetails_2(""); // Interzone surfaces - different zones
-    auto constexpr MoreDetails_3(
-        "Node connection errors are often caused by spelling mistakes in a node name field.<CR>To track down the problem, search the "
-        "idf file for each node name listed to see if it<CR>occurs in the expected input fields.<CRE>"); // Node Connection Errors
-    auto constexpr MoreDetails_4("The azimuths (outward facing angle) of two interzone surfaces should not be the same.<CR>Normally, the absolute "
-                                 "difference between the two azimuths will be 180 degrees.<CR>You can turn on the report: "
-                                 "Output:Surfaces:List,Details; to inspect your surfaces.<CRE>"); // InterZone Surface Azimuths -- mismatch
-    auto constexpr MoreDetails_5("");                                                             // InterZone Surface Tilts -- mismatch
-    auto constexpr MoreDetails_6("EnergyPlus Surfaces should be planar. If the error indicates a small increment for the<CR>out of planar bounds, "
-                                 "then the calculations are likely okay though you should try to fix<CR>the problem. If a greater increment, the "
-                                 "calculations will likely be incorrect.<CRE>"); // Likely non-planar surfaces
-    auto constexpr MoreDetails_7(
-        "A deprecated feature warning/severe error indicates that you are using a feature which will be<CR>removed in a future "
-        "release. The new feature is likely included in the EnergyPlus version you are<CR>using.  Consider switching now to avoid "
-        "future problems.<CR>A deprecated key value message indicates you are using an out-dated key value in your input "
-        "file.<CR>While EnergyPlus may continue to accept these values, some other input file readers may not.<CR>Consider changing to "
-        "values that are included as valid in the Energy+.idd for these objects.<CRE>"); // Deprecated Features or Key Values
-    auto constexpr MoreDetails_8("Floors are usually flat and \"tilted\" 180 degrees.  If you get this error message,<CR>it's likely that you "
-                                 "need to reverse the vertices of the surface to remove the error.<CR>EnergyPlus will attempt to fix the vertices "
-                                 "for the running simulation.<CR>You can turn on the report: Output:Surfaces:List,Details; to inspect your "
-                                 "surfaces.<CRE>"); // Incorrect Floor Tilt
-    auto constexpr MoreDetails_9("Flat roofs/ceilings are \"tilted\" 0 degrees. Pitched roofs should be \"near\" 0 degrees.<CR>If you get this "
-                                 "error message, it's likely that you need to reverse the vertices of<CR>the surface to remove the error. "
-                                 "EnergyPlus will attempt to fix the vertices for the<CR>running simulation. You can turn on the report: "
-                                 "Output:Surfaces:List,Details;<CR>to inspect your surfaces.<CRE>"); // Incorrect Roof/Ceiling Tilt
-    auto constexpr MoreDetails_10(
-        "Incomplete view factors can result from incorrect floor specifications (such as tilting 0<CR>instead of 180) or not enough "
-        "surfaces in a zone to make an enclosure.  The error message<CR>also shows an enforced reciprocity value.  You can decide if "
-        "you need to make geometry<CR>changes based on that value.<CRE>"); // Incomplete View factors
-    auto constexpr MoreDetails_11("Unbalanced exhaust air flow errors can occur when exhaust fans are running but there is no<CR>supply air. Turn "
-                                  "off exhaust fans when the system is not running may help resolve the problem.<CR>Time shown is first "
-                                  "occurrence of error.<CRE>"); // Unbalanced exhaust air flow
-    auto constexpr MoreDetails_12(
-        "1) very high thermal mass such as very thick concrete (solution: increase max number of warmup<CR>   days in the BUILDING "
-        "object);<CR>2) moderate mass and inadequate space conditioning such that the building keeps getting warmer<CR>   and warmer "
-        "on successive days (solution: add HVAC, check building thermal properties,<CR>   check if infiltration is included, make "
-        "sure HVAC properly controlled);<CR>3) a soil layer modeled below the concrete slab - (solution remove this layer and read "
-        "about<CR>   ground temperatures in the Auxiliary Programs document).<CR>4) unreasonable (too small) limits in the BUILDING "
-        "object for temperature (.4 default) or<CR>   loads tolerances (.04 default)<CRE>"); // Loads Initialization did not Converge
-    auto constexpr MoreDetails_13(
-        "Window is too close to map points for accurate calculation.  Suggested change is to create<CR>Output:IlluminanceMap "
-        "coordinates (x,y,z) that are more \"inside\" the zone<CRE>"); // CalcDaylightMapPoints: Window
-    auto constexpr MoreDetails_14("Zone Air Heat Balance out of Balance warnings are currently used by developers.<CR>Users can safely ignore "
-                                  "these warnings.<CRE>"); // Zone Air Heat Balance Warnings
-    auto constexpr MoreDetails_15("The occupant density warning is provided to alert you to potential conditions that can cause<CR>problems with "
-                                  "the heat balance calculations. Too high a density could be cause for severe<CR>temperature out of bounds "
-                                  "errors in a zone leading to program termination.<CRE>"); // Occupant density is extremely high
-    auto constexpr MoreDetails_16(
-        "A temperature out of bounds problem can be caused by several things. The user should check:<CR>1) the weather environment "
-        "(including the horizontal IR from sky)<CR>2) the level of internal gains with respect to the zone<CR>3) the thermal "
-        "properties of their materials.  And other things.<CR>A common cause is a building with no or little thermal mass - all "
-        "materials with Material:NoMass definitions.<CRE>"); // Temperature (low) out of bounds AND Temperature (high) out of bounds
-    auto constexpr MoreDetails_18(
-        "The nominally unused constructions warning is provided to alert you to potential conditions that can cause<CR>extra time "
-        "during simulation. Each construction is calculated by the algorithm indicated in the HeatBalanceAlgorithm<CR>object. You may "
-        "remove the constructions indicated (when you use the DisplayExtraWarnings option).<CRE>"); // Nominally unused constructions
-    auto constexpr MoreDetails_19(
-        "Using Material:InfraredTransparent materials in constructions are correctly used in interzone surface<CR>constructions. "
-        "Warnings are given if they are used in other kinds of surfaces.<CR>They CANNOT currently be used with "
-        "ConductionFiniteDifference algorithms.<CRE>"); // InfraredTransparent constructions in non-interzone surfaces
-    auto constexpr MoreDetails_20(
-        "No Reporting elements have been requested. You will see no output values from your run.<CR>Add Output:Variable, "
-        "Output:Meter, Output:Table:SummaryReports, Output:Table:Monthly, Output:Table:TimeBins<CR>objects to your input file to "
-        "receive output values from the simulation.<CRE>"); // No reporting elements requested
-
-    std::array<const char *, 21> constexpr MoreDetails({MoreDetails_0,  MoreDetails_1,  MoreDetails_2,  MoreDetails_3,  MoreDetails_4,
-                                                        MoreDetails_5,  MoreDetails_6,  MoreDetails_7,  MoreDetails_8,  MoreDetails_9,
-                                                        MoreDetails_10, MoreDetails_11, MoreDetails_12, MoreDetails_13, MoreDetails_14,
-                                                        MoreDetails_15, MoreDetails_16, MoreDetails_16, MoreDetails_18, MoreDetails_19,
-                                                        MoreDetails_20}); // Details 16 applies to both temperature out of bounds |
+    // See also in UtilityRoutines.cc: struct ErrorSummaryInfo and
+    // constexpr std::array<ErrorSummaryInfo, static_cast<size_t>(ErrorSummaryType::Num)> ErrorSummaries
+    enum class ErrorSummaryType
+    {
+        InterZoneSurfaceAreaMismatch = 0,  // "InterZone Surface Areas"
+        InterZoneSurfaceDifferentZones,    // "CAUTION -- Interzone"
+        NodeConnectionErrors,              // "Node Connection Error"
+        InterZoneSurfaceAzimuthMismatch,   // "InterZone Surface Azimu"
+        InterZoneSurfaceTiltMismatch,      // "InterZone Surface Tilts"
+        NonPlanarSurfaces,                 // "Suspected non-planar"
+        DeprecatedFeaturesOrKeyValues,     // "Deprecated"
+        IncorrectFloorTilt,                // "Floor Tilt="
+        IncorrectRoofCeilingTilt,          // "Roof/Ceiling Tilt="
+        IncompleteViewFactors,             // "View factors not"
+        UnbalancedExhaustAirFlow,          // "Unbalanced exhaust air"
+        LoadsInitializationDidNotConverge, // "Loads Initialization"
+        DaylightMapPointsNearWindow,       // "CalcDaylightMapPoints:"
+        ZoneAirHeatBalanceWarnings,        // "Zone Air Heat Balance"
+        OccupantDensityExtremelyHigh,      // "occupant density is ext"
+        TemperatureLowOutOfBounds,         // "Temperature (low) out o"
+        TemperatureHighOutOfBounds,        // "Temperature (high) out"
+        NominallyUnusedConstructions,      // "nominally unused"
+        InfraredTransparentUsage,          // "InfraredTransparent"
+        NoReportingElementsRequested,      // "No reporting elements"
+        Num
+    };
 
     struct RecurringErrorData
     {
@@ -205,7 +109,7 @@ namespace DataErrorTracking {
 struct ErrorTrackingData : BaseGlobalStruct
 {
     Array1D<DataErrorTracking::RecurringErrorData> RecurringErrors;
-    Array1D_int MatchCounts;
+    std::array<int, static_cast<size_t>(DataErrorTracking::ErrorSummaryType::Num)> ErrorSummaryCount{};
     bool AbortProcessing = false;            // Flag used to if currently in "abort processing"
     int NumRecurringErrors = 0;              // Number of stored recurring error messages
     int TotalSevereErrors = 0;               // Counter
@@ -226,11 +130,6 @@ struct ErrorTrackingData : BaseGlobalStruct
     bool AskForPlantCheckOnAbort = false;    // flag used to tell if plant structure can be checked
     bool ExitDuringSimulations = false;      // flag used to tell if program is in simulation mode when fatal occurs
     std::string LastSevereError;
-
-    ErrorTrackingData()
-    {
-        MatchCounts = Array1D_int(DataErrorTracking::SearchCounts, 0);
-    }
 
     void init_constant_state([[maybe_unused]] EnergyPlusData &state) override
     {

--- a/src/EnergyPlus/DataErrorTracking.hh
+++ b/src/EnergyPlus/DataErrorTracking.hh
@@ -48,16 +48,12 @@
 #ifndef DataErrorTracking_hh_INCLUDED
 #define DataErrorTracking_hh_INCLUDED
 
-#include <string>
-#include <unordered_map>
-
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array1D.hh>
 
 // EnergyPlus Headers
 #include <EnergyPlus/Data/BaseData.hh>
 #include <EnergyPlus/EnergyPlus.hh>
-#include <EnergyPlus/UtilityRoutines.hh>
 
 namespace EnergyPlus {
 
@@ -209,9 +205,6 @@ namespace DataErrorTracking {
 struct ErrorTrackingData : BaseGlobalStruct
 {
     Array1D<DataErrorTracking::RecurringErrorData> RecurringErrors;
-    // Maps a recurring error's full message text (e.g. " ** Warning ** ...") to its 1-based index in
-    // RecurringErrors, so repeat occurrences are resolved in O(1) instead of a linear SameString scan.
-    std::unordered_map<std::string, int, Util::case_insensitive_hasher, Util::case_insensitive_comparator> RecurringErrorIndexByMessage;
     Array1D_int MatchCounts;
     bool AbortProcessing = false;            // Flag used to if currently in "abort processing"
     int NumRecurringErrors = 0;              // Number of stored recurring error messages

--- a/src/EnergyPlus/DataErrorTracking.hh
+++ b/src/EnergyPlus/DataErrorTracking.hh
@@ -48,12 +48,16 @@
 #ifndef DataErrorTracking_hh_INCLUDED
 #define DataErrorTracking_hh_INCLUDED
 
+#include <string>
+#include <unordered_map>
+
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array1D.hh>
 
 // EnergyPlus Headers
 #include <EnergyPlus/Data/BaseData.hh>
 #include <EnergyPlus/EnergyPlus.hh>
+#include <EnergyPlus/UtilityRoutines.hh>
 
 namespace EnergyPlus {
 
@@ -205,6 +209,9 @@ namespace DataErrorTracking {
 struct ErrorTrackingData : BaseGlobalStruct
 {
     Array1D<DataErrorTracking::RecurringErrorData> RecurringErrors;
+    // Maps a recurring error's full message text (e.g. " ** Warning ** ...") to its 1-based index in
+    // RecurringErrors, so repeat occurrences are resolved in O(1) instead of a linear SameString scan.
+    std::unordered_map<std::string, int, Util::case_insensitive_hasher, Util::case_insensitive_comparator> RecurringErrorIndexByMessage;
     Array1D_int MatchCounts;
     bool AbortProcessing = false;            // Flag used to if currently in "abort processing"
     int NumRecurringErrors = 0;              // Number of stored recurring error messages

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.cc
@@ -2990,11 +2990,12 @@ namespace HVACMultiSpeedHeatPump {
             }
         }
         if (useMaxedSpeed) {
-            MSHeatPump.CoilSpeedErrIndex++;
+            int &coilSpeedErrIndex =
+                (MSHeatPump.HeatCoolMode == ModeOfOperation::HeatingMode) ? MSHeatPump.CoilSpeedErrIndexHeating : MSHeatPump.CoilSpeedErrIndexCooling;
             ShowRecurringWarningErrorAtEnd(state,
                                            "Wrong coil speed EMS override value, for unit=\"" + useMaxedSpeedCoilName +
                                                "\". Exceeding maximum coil speed level. Speed level is set to the maximum coil speed level allowed.",
-                                           MSHeatPump.CoilSpeedErrIndex,
+                                           coilSpeedErrIndex,
                                            SpeedVal,
                                            SpeedVal,
                                            _,

--- a/src/EnergyPlus/HVACMultiSpeedHeatPump.hh
+++ b/src/EnergyPlus/HVACMultiSpeedHeatPump.hh
@@ -208,7 +208,8 @@ namespace HVACMultiSpeedHeatPump {
         bool MyStagedFlag;
         bool EMSOverrideCoilSpeedNumOn;
         Real64 EMSOverrideCoilSpeedNumValue;
-        int CoilSpeedErrIndex;
+        int CoilSpeedErrIndexHeating;
+        int CoilSpeedErrIndexCooling;
         Real64 HeatingSizingRatio = 1.0;
         bool isHeatPump = false;
         bool reportACCAManualS = true;
@@ -232,7 +233,7 @@ namespace HVACMultiSpeedHeatPump {
               StageNum(0), Staged(false), CoolCountAvail(0), CoolIndexAvail(0), HeatCountAvail(0), HeatIndexAvail(0), FirstPass(true),
               MinOATCompressorCooling(0.0), MinOATCompressorHeating(0.0), MyEnvrnFlag(true), MySizeFlag(true), MyCheckFlag(true),
               MyFlowFracFlag(true), MyPlantScantFlag(true), MyStagedFlag(true), EMSOverrideCoilSpeedNumOn(false), EMSOverrideCoilSpeedNumValue(0.0),
-              CoilSpeedErrIndex(0)
+              CoilSpeedErrIndexHeating(0), CoilSpeedErrIndexCooling(0)
         {
         }
     };

--- a/src/EnergyPlus/HeatBalFiniteDiffManager.cc
+++ b/src/EnergyPlus/HeatBalFiniteDiffManager.cc
@@ -2574,6 +2574,7 @@ namespace HeatBalFiniteDiffManager {
         if (!state.dataGlobal->WarmupFlag || s_hbfd->WarmupSurfTemp > 10 || state.dataGlobal->DisplayExtraWarnings) {
             if (CheckTemperature < DataHeatBalSurface::MinSurfaceTempLimit) {
                 if (state.dataSurface->SurfLowTempErrCount(SurfNum) == 0) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                     ShowSevereMessage(state,
                                       std::format("Temperature (low) out of bounds [{:.2f}] for zone=\"{}\", for surface=\"{}\"",
                                                   CheckTemperature,
@@ -2629,6 +2630,7 @@ namespace HeatBalFiniteDiffManager {
                 }
             } else {
                 if (state.dataSurface->SurfHighTempErrCount(SurfNum) == 0) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                     ShowSevereMessage(state,
                                       std::format("Temperature (high) out of bounds ({:.2f}] for zone=\"{}\", for surface=\"{}\"",
                                                   CheckTemperature,

--- a/src/EnergyPlus/HeatBalFiniteDiffManager.cc
+++ b/src/EnergyPlus/HeatBalFiniteDiffManager.cc
@@ -62,6 +62,7 @@
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
@@ -718,6 +719,7 @@ namespace HeatBalFiniteDiffManager {
                     Alpha = kt / (mat->Density * mat->SpecHeat);
                     mAlpha = 0.0;
                 } else if (thisConstruct.TypeIsIRT) { // make similar to air? (that didn't seem to work well)
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::InfraredTransparentUsage)];
                     ShowSevereError(
                         state,
                         std::format("InitHeatBalFiniteDiff: Construction =\"{}\" uses Material:InfraredTransparent. Cannot be used currently "

--- a/src/EnergyPlus/HeatBalanceHAMTManager.cc
+++ b/src/EnergyPlus/HeatBalanceHAMTManager.cc
@@ -58,6 +58,7 @@
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
 #include <EnergyPlus/DataIPShortCuts.hh>
@@ -1377,6 +1378,7 @@ namespace HeatBalanceHAMTManager {
             tempmax = maxval(s_hbh->cells, &subcell::tempp1);
             tempmin = minval(s_hbh->cells, &subcell::tempp1);
             if (tempmax > state.dataHeatBalSurf->MaxSurfaceTempLimit) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
                     if (state.dataSurface->SurfHighTempErrCount(sid) == 0) {
                         ShowSevereMessage(state,
@@ -1397,6 +1399,7 @@ namespace HeatBalanceHAMTManager {
                 }
             }
             if (tempmax > state.dataHeatBalSurf->MaxSurfaceTempLimitBeforeFatal) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
                     ShowSevereError(state,
                                     std::format("HAMT: HAMT: Temperature (high) out of bounds ( {:.2f}) for surface={}",
@@ -1407,6 +1410,7 @@ namespace HeatBalanceHAMTManager {
                 }
             }
             if (tempmin < MinSurfaceTempLimit) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
                     if (state.dataSurface->SurfHighTempErrCount(sid) == 0) {
                         ShowSevereMessage(state,
@@ -1427,6 +1431,7 @@ namespace HeatBalanceHAMTManager {
                 }
             }
             if (tempmin < MinSurfaceTempLimitBeforeFatal) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
                     ShowSevereError(state,
                                     std::format("HAMT: HAMT: Temperature (low) out of bounds ( {:.2f}) for surface={}",

--- a/src/EnergyPlus/HeatBalanceHAMTManager.cc
+++ b/src/EnergyPlus/HeatBalanceHAMTManager.cc
@@ -1378,8 +1378,8 @@ namespace HeatBalanceHAMTManager {
             tempmax = maxval(s_hbh->cells, &subcell::tempp1);
             tempmin = minval(s_hbh->cells, &subcell::tempp1);
             if (tempmax > state.dataHeatBalSurf->MaxSurfaceTempLimit) {
-                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                     if (state.dataSurface->SurfHighTempErrCount(sid) == 0) {
                         ShowSevereMessage(state,
                                           std::format("HAMT: Temperature (high) out of bounds ({:.2f}) for surface={}",
@@ -1399,8 +1399,8 @@ namespace HeatBalanceHAMTManager {
                 }
             }
             if (tempmax > state.dataHeatBalSurf->MaxSurfaceTempLimitBeforeFatal) {
-                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                     ShowSevereError(state,
                                     std::format("HAMT: HAMT: Temperature (high) out of bounds ( {:.2f}) for surface={}",
                                                 tempmax,
@@ -1410,8 +1410,8 @@ namespace HeatBalanceHAMTManager {
                 }
             }
             if (tempmin < MinSurfaceTempLimit) {
-                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                     if (state.dataSurface->SurfHighTempErrCount(sid) == 0) {
                         ShowSevereMessage(state,
                                           std::format("HAMT: Temperature (low) out of bounds ({:.2f}) for surface={}",
@@ -1431,8 +1431,8 @@ namespace HeatBalanceHAMTManager {
                 }
             }
             if (tempmin < MinSurfaceTempLimitBeforeFatal) {
-                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                 if (!state.dataGlobal->WarmupFlag) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                     ShowSevereError(state,
                                     std::format("HAMT: HAMT: Temperature (low) out of bounds ( {:.2f}) for surface={}",
                                                 tempmin,

--- a/src/EnergyPlus/HeatBalanceIntRadExchange.cc
+++ b/src/EnergyPlus/HeatBalanceIntRadExchange.cc
@@ -58,6 +58,7 @@
 // EnergyPlus Headers
 #include <EnergyPlus/Construction.hh>
 #include <EnergyPlus/Data/EnergyPlusData.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
 #include <EnergyPlus/DataIPShortCuts.hh>
@@ -1731,6 +1732,7 @@ namespace HeatBalanceIntRadExchange {
                             std::format("FixViewFactors: View factors convergence has failed and will lead to heat balance errors in zone=\"{}\".",
                                         enclName));
                     }
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::IncompleteViewFactors)];
                     ShowWarningError(
                         state,
                         std::format("FixViewFactors: View factors not complete. Check for bad surface descriptions or unenclosed zone=\"{}\".",
@@ -1774,6 +1776,7 @@ namespace HeatBalanceIntRadExchange {
                 F = FixedF;
                 FinalCheckValue = FixedCheckValue;
             } else {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::IncompleteViewFactors)];
                 ShowWarningError(
                     state,
                     std::format("FixViewFactors: View factors not complete. Check for bad surface descriptions or unenclosed zone=\"{}\".",

--- a/src/EnergyPlus/HeatBalanceManager.cc
+++ b/src/EnergyPlus/HeatBalanceManager.cc
@@ -65,6 +65,7 @@
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataBSDFWindow.hh>
 #include <EnergyPlus/DataContaminantBalance.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
@@ -389,6 +390,7 @@ namespace HeatBalanceManager {
                                                                       state.dataConstruction->Construct.end(),
                                                                       [](Construction::ConstructionProps const &e) { return e.IsUsed; });
         if (Unused > 0) {
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NominallyUnusedConstructions)];
             if (!state.dataGlobal->DisplayExtraWarnings) {
                 ShowWarningError(state, std::format("CheckUsedConstructions: There are {} nominally unused constructions in input.", Unused));
                 ShowContinueError(state, "For explicit details on each unused construction, use Output:Diagnostics,DisplayExtraWarnings;");
@@ -3383,6 +3385,8 @@ namespace HeatBalanceManager {
                 if (state.dataGlobal->DayOfSim >= state.dataHeatBal->MaxNumberOfWarmupDays && state.dataGlobal->WarmupFlag) {
                     // Check convergence for individual zone
                     if (sum(state.dataHeatBalMgr->WarmupConvergenceValues(ZoneNum).PassFlag) != 8) { // pass=2 * 4 values for convergence
+                        ++state.dataErrTracking
+                              ->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::LoadsInitializationDidNotConverge)];
                         ShowSevereError(
                             state,
                             std::format("CheckWarmupConvergence: Loads Initialization, Zone=\"{}\" did not converge after {} warmup days.",

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.cc
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.cc
@@ -76,6 +76,7 @@
 #include <EnergyPlus/DataDaylighting.hh>
 #include <EnergyPlus/DataDaylightingDevices.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
 #include <EnergyPlus/DataHeatBalance.hh>
@@ -9477,6 +9478,7 @@ void TestSurfTempCalcHeatBalanceInsideSurf(EnergyPlusData &state, Real64 TH12, i
         }
         if (!state.dataGlobal->WarmupFlag || WarmupSurfTemp > 10 || state.dataGlobal->DisplayExtraWarnings) {
             if (TH12 < DataHeatBalSurface::MinSurfaceTempLimit) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                 if (state.dataSurface->SurfLowTempErrCount(SurfNum) == 0) {
                     ShowSevereMessage(
                         state, std::format(R"(Temperature (low) out of bounds [{:.2f}] for zone="{}", for surface="{}")", TH12, zone.Name, surfName));
@@ -9520,6 +9522,7 @@ void TestSurfTempCalcHeatBalanceInsideSurf(EnergyPlusData &state, Real64 TH12, i
                                                   "C");
                 }
             } else {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                 if (state.dataSurface->SurfHighTempErrCount(SurfNum) == 0) {
                     ShowSevereMessage(
                         state,
@@ -9578,6 +9581,7 @@ void TestSurfTempCalcHeatBalanceInsideSurf(EnergyPlusData &state, Real64 TH12, i
     if ((TH12 > state.dataHeatBalSurf->MaxSurfaceTempLimitBeforeFatal) || (TH12 < DataHeatBalSurface::MinSurfaceTempLimitBeforeFatal)) {
         if (!state.dataGlobal->WarmupFlag) {
             if (TH12 < DataHeatBalSurface::MinSurfaceTempLimitBeforeFatal) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureLowOutOfBounds)];
                 ShowSevereError(
                     state, std::format(R"(Temperature (low) out of bounds [{:.2f}] for zone="{}", for surface="{}")", TH12, zone.Name, surfName));
                 ShowContinueErrorTimeStamp(state, "");
@@ -9603,6 +9607,7 @@ void TestSurfTempCalcHeatBalanceInsideSurf(EnergyPlusData &state, Real64 TH12, i
                 }
                 ShowFatalError(state, "Program terminates due to preceding condition.");
             } else {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::TemperatureHighOutOfBounds)];
                 ShowSevereError(
                     state, std::format(R"(Temperature (high) out of bounds [{:.2f}] for zone="{}", for surface="{}")", TH12, zone.Name, surfName));
                 ShowContinueErrorTimeStamp(state, "");

--- a/src/EnergyPlus/HeatBalanceSurfaceManager.cc
+++ b/src/EnergyPlus/HeatBalanceSurfaceManager.cc
@@ -2384,11 +2384,14 @@ void InitThermalAndFluxHistories(EnergyPlusData &state)
 
     // First do the "bulk" initializations of arrays sized to NumOfZones
     for (int zoneNum = 1; zoneNum <= state.dataGlobal->NumOfZones; ++zoneNum) {
+        // Save and restore the MsgIndex for Recurring errors
+        const int hmThermalMassMultErrIndex = state.dataZoneTempPredictorCorrector->zoneHeatBalance(zoneNum).hmThermalMassMultErrIndex;
         new (&state.dataZoneTempPredictorCorrector->zoneHeatBalance(zoneNum)) ZoneTempPredictorCorrector::ZoneHeatBalanceData();
         // Initialize the Zone Humidity Ratio here so that it is available for EMPD implementations
         auto &thisZoneHB = state.dataZoneTempPredictorCorrector->zoneHeatBalance(zoneNum);
         thisZoneHB.airHumRatAvg = state.dataEnvrn->OutHumRat;
         thisZoneHB.airHumRat = state.dataEnvrn->OutHumRat;
+        thisZoneHB.hmThermalMassMultErrIndex = hmThermalMassMultErrIndex;
         state.dataHeatBalFanSys->TempTstatAir(zoneNum) = DataHeatBalance::ZoneInitialTemp;
     }
     for (auto &thisEnclosure : state.dataViewFactor->EnclRadInfo) {

--- a/src/EnergyPlus/HeatRecovery.cc
+++ b/src/EnergyPlus/HeatRecovery.cc
@@ -3873,7 +3873,7 @@ namespace HeatRecovery {
                                                                "equation is out of range error continues...",
                                                                state.dataHeatRecovery->BalDesDehumPerfData(this->PerfDataIndex).PerfType,
                                                                state.dataHeatRecovery->BalDesDehumPerfData(this->PerfDataIndex).Name),
-                                                   state.dataHeatRecovery->BalDesDehumPerfData(this->PerfDataIndex).T_ProcInHumRatError.index,
+                                                   state.dataHeatRecovery->BalDesDehumPerfData(this->PerfDataIndex).H_ProcInHumRatError.index,
                                                    state.dataHeatRecovery->BalDesDehumPerfData(this->PerfDataIndex).H_ProcInHumRatError.last,
                                                    state.dataHeatRecovery->BalDesDehumPerfData(this->PerfDataIndex).H_ProcInHumRatError.last);
                 }

--- a/src/EnergyPlus/InternalHeatGains.cc
+++ b/src/EnergyPlus/InternalHeatGains.cc
@@ -66,6 +66,7 @@
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataContaminantBalance.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataGlobalConstants.hh>
 #include <EnergyPlus/DataHVACGlobals.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
@@ -1285,6 +1286,8 @@ namespace InternalHeatGains {
                 if (state.dataHeatBal->Zone(Loop).TotOccupants > 0.0) {
                     if (state.dataHeatBal->Zone(Loop).FloorArea > 0.0 &&
                         state.dataHeatBal->Zone(Loop).FloorArea / state.dataHeatBal->Zone(Loop).TotOccupants < 0.1) {
+                        ++state.dataErrTracking
+                              ->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::OccupantDensityExtremelyHigh)];
                         ShowWarningError(
                             state, std::format("{}Zone=\"{}\" occupant density is extremely high.", RoutineName, state.dataHeatBal->Zone(Loop).Name));
                         if (state.dataHeatBal->Zone(Loop).FloorArea > 0.0) {

--- a/src/EnergyPlus/PlantLoopHeatPumpEIR.cc
+++ b/src/EnergyPlus/PlantLoopHeatPumpEIR.cc
@@ -978,7 +978,7 @@ void EIRPlantLoopHeatPump::heatRecoveryEIRModCurveCheck(EnergyPlusData &state, R
             std::format("{} \"{}\": Heat Recovery mode EIR Modifier curve (function of Temperatures) output is negative warning continues...",
                         DataPlant::PlantEquipTypeNames[static_cast<int>(this->EIRHPType)],
                         this->name),
-            this->eirModFTErrorIndex,
+            this->heatRecEIRModFTErrorIndex,
             eirModifierFuncTemp,
             eirModifierFuncTemp);
         eirModifierFuncTemp = 0.0;

--- a/src/EnergyPlus/SimulationManager.cc
+++ b/src/EnergyPlus/SimulationManager.cc
@@ -1762,6 +1762,7 @@ namespace SimulationManager {
                  state.dataInputProcessing->inputProcessor->getNumObjectsFound(state, "Output:Meter:Cumulative:MeterFileOnly") > 0);
             // Not testing for : Output:SQLite or Output:EnvironmentalImpactFactors
             if (!ReportingRequested) {
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NoReportingElementsRequested)];
                 ShowWarningError(state, "No reporting elements have been requested. No simulation results produced.");
                 ShowContinueError(state,
                                   "...Review requirements such as \"Output:Table:SummaryReports\", \"Output:Table:Monthly\", \"Output:Variable\", "
@@ -2328,6 +2329,7 @@ namespace SimulationManager {
                 ShowContinueError(state, std::format("  Inlet Node : {}", state.dataBranchNodeConnections->CompSets(Count).InletNodeName));
                 ShowContinueError(state, std::format("  Outlet Node: {}", state.dataBranchNodeConnections->CompSets(Count).OutletNodeName));
                 ++state.dataBranchNodeConnections->NumNodeConnectionErrors;
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
                 if (state.dataBranchNodeConnections->CompSets(Count).ComponentObjectType ==
                     Node::ConnectionObjectType::SolarCollectorUnglazedTranspired) {
                     ShowContinueError(state, "This report does not necessarily indicate a problem for a MultiSystem Transpired Collector");
@@ -2349,6 +2351,7 @@ namespace SimulationManager {
                 ShowContinueError(state, std::format("  Outlet Node: {}", state.dataBranchNodeConnections->CompSets(Count).OutletNodeName));
                 nodeConnectionErrorFlag = true;
                 ++state.dataBranchNodeConnections->NumNodeConnectionErrors;
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NodeConnectionErrors)];
             }
         }
 

--- a/src/EnergyPlus/SingleDuct.cc
+++ b/src/EnergyPlus/SingleDuct.cc
@@ -4590,19 +4590,19 @@ void SingleDuctAirTerminal::SimVAVVS(EnergyPlusData &state, bool const FirstHVAC
                                                MaxHeatMassFlow,
                                                state.dataSingleDuct->sd_airterminal(this->SysNum).solveRootStats);
                 if (SolFlag == General::SOLVEROOT_ERROR_ITER) {
-                    if (this->IterationLimit == 0) {
+                    if (this->IterationLimitSteamCoil == 0) {
                         ShowWarningError(state, std::format("Steam heating coil control failed in VS VAV terminal unit {}", this->SysName));
                         ShowContinueError(state, "  Iteration limit exceeded in calculating air flow rate");
                     }
                     ShowRecurringWarningErrorAtEnd(
-                        state, "Steam heating coil iteration limit exceeded in VS VAV terminal unit " + this->SysName, this->IterationLimit);
+                        state, "Steam heating coil iteration limit exceeded in VS VAV terminal unit " + this->SysName, this->IterationLimitSteamCoil);
                 } else if (SolFlag == General::SOLVEROOT_ERROR_INIT) {
-                    if (this->IterationFailed == 0) {
+                    if (this->IterationFailedSteamCoil == 0) {
                         ShowWarningError(state, std::format("Steam heating coil control failed in VS VAV terminal unit {}", this->SysName));
                         ShowContinueError(state, "  Bad air flow limits");
                     }
                     ShowRecurringWarningErrorAtEnd(
-                        state, "Steam heating coil control failed in VS VAV terminal unit " + this->SysName, this->IterationFailed);
+                        state, "Steam heating coil control failed in VS VAV terminal unit " + this->SysName, this->IterationFailedSteamCoil);
                 }
             } else {
                 MassFlow = MaxHeatMassFlow;
@@ -4639,19 +4639,20 @@ void SingleDuctAirTerminal::SimVAVVS(EnergyPlusData &state, bool const FirstHVAC
                     state, UnitFlowToler, 50, SolFlag, f, 0.0, 1.0, state.dataSingleDuct->sd_airterminal(this->SysNum).solveRootStats);
                 MassFlow = state.dataLoopNodes->Node(SysInletNode).MassFlowRate;
                 if (SolFlag == General::SOLVEROOT_ERROR_ITER) {
-                    if (this->IterationLimit == 0) {
+                    if (this->IterationLimitHeatingCoil == 0) {
                         ShowWarningError(state, std::format("Heating coil control failed in VS VAV terminal unit {}", this->SysName));
                         ShowContinueError(state, "  Iteration limit exceeded in calculating air flow rate");
                     }
-                    ShowRecurringWarningErrorAtEnd(
-                        state, "Heating coil control iteration limit exceeded in VS VAV terminal unit " + this->SysName, this->IterationLimit);
+                    ShowRecurringWarningErrorAtEnd(state,
+                                                   "Heating coil control iteration limit exceeded in VS VAV terminal unit " + this->SysName,
+                                                   this->IterationLimitHeatingCoil);
                 } else if (SolFlag == General::SOLVEROOT_ERROR_INIT) {
-                    if (this->IterationFailed == 0) {
+                    if (this->IterationFailedHeatingCoil == 0) {
                         ShowWarningError(state, std::format("Heating coil control failed in VS VAV terminal unit {}", this->SysName));
                         ShowContinueError(state, "  Bad air flow limits");
                     }
                     ShowRecurringWarningErrorAtEnd(
-                        state, "Heating coil control failed in VS VAV terminal unit " + this->SysName, this->IterationFailed);
+                        state, "Heating coil control failed in VS VAV terminal unit " + this->SysName, this->IterationFailedHeatingCoil);
                 }
             } else {
                 MassFlow = MaxHeatMassFlow;

--- a/src/EnergyPlus/SingleDuct.hh
+++ b/src/EnergyPlus/SingleDuct.hh
@@ -192,8 +192,15 @@ namespace SingleDuct {
         std::string ZoneHVACUnitName; // name of Zone HVAC unit for air terminal mixer units
         int SecInNode;                // zone or zone unit air node number
         // warning variables
-        int IterationLimit;                                       // Used for RegulaFalsi error -1
-        int IterationFailed;                                      // Used for RegulaFalsi error -2
+        // VS VAV terminal: separate recurring-error indices per distinct message, since the supply air
+        // flow solve (cooling and heating) always runs regardless of reheat coil type, and can co-occur
+        // with the reheat-coil-specific solves below (which are themselves mutually exclusive by coil type).
+        int IterationLimit;                                       // Used for RegulaFalsi error -1, supply air flow solve
+        int IterationFailed;                                      // Used for RegulaFalsi error -2, supply air flow solve
+        int IterationLimitSteamCoil;                              // Used for RegulaFalsi error -1, steam heating coil control solve
+        int IterationFailedSteamCoil;                             // Used for RegulaFalsi error -2, steam heating coil control solve
+        int IterationLimitHeatingCoil;                            // Used for RegulaFalsi error -1, gas/electric heating coil control solve
+        int IterationFailedHeatingCoil;                           // Used for RegulaFalsi error -2, gas/electric heating coil control solve
         DataZoneEquipment::PerPersonVentRateMode OAPerPersonMode; // mode for how per person rates are determined, DCV or design.
         bool EMSOverrideAirFlow;                                  // if true, EMS is calling to override flow rate
         Real64 EMSMassFlowRateValue;                              // value EMS is directing to use for flow rate [kg/s]
@@ -224,7 +231,8 @@ namespace SingleDuct {
               DamperPosition(0.0), ADUNum(0), ErrCount1(0), ErrCount1c(0), ErrCount2(0), ZoneFloorArea(0.0), CtrlZoneNum(0), CtrlZoneInNodeIndex(0),
               MaxAirVolFlowRateDuringReheat(0.0), MaxAirVolFractionDuringReheat(0.0), AirMassFlowDuringReheatMax(0.0), ZoneOutdoorAirMethod(0),
               OutdoorAirFlowRate(0.0), NoOAFlowInputFromUser(true), OARequirementsPtr(0), AirLoopNum(0), HWplantLoc{}, SecInNode(0),
-              IterationLimit(0), IterationFailed(0), OAPerPersonMode(DataZoneEquipment::PerPersonVentRateMode::Invalid), EMSOverrideAirFlow(false),
+              IterationLimit(0), IterationFailed(0), IterationLimitSteamCoil(0), IterationFailedSteamCoil(0), IterationLimitHeatingCoil(0),
+              IterationFailedHeatingCoil(0), OAPerPersonMode(DataZoneEquipment::PerPersonVentRateMode::Invalid), EMSOverrideAirFlow(false),
               EMSMassFlowRateValue(0.0), ZoneTurndownMinAirFrac(1.0), MyEnvrnFlag(true), MySizeFlag(true), GetGasElecHeatCoilCap(true),
               PlantLoopScanFlag(true), MassFlow1(0.0), MassFlow2(0.0), MassFlow3(0.0), MassFlowDiff(0.0)
         {

--- a/src/EnergyPlus/SurfaceGeometry.cc
+++ b/src/EnergyPlus/SurfaceGeometry.cc
@@ -1928,6 +1928,8 @@ namespace SurfaceGeometry {
                                               state.dataSurface->Surface(SurfNum).Area * MultSurfNum) /
                                              state.dataSurface->Surface(Found).Area * MultFound) > 0.02) { // 2% difference in areas
                                     ++state.dataSurfaceGeometry->ErrCount4;
+                                    ++state.dataErrTracking
+                                          ->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::InterZoneSurfaceAreaMismatch)];
                                     if (state.dataSurfaceGeometry->ErrCount4 == 1 && !state.dataGlobal->DisplayExtraWarnings) {
                                         ShowWarningError(
                                             state,
@@ -1978,6 +1980,8 @@ namespace SurfaceGeometry {
                             // Check opposites Azimuth and Tilt
                             // Tilt
                             if (std::abs(std::abs(state.dataSurface->Surface(Found).Tilt + state.dataSurface->Surface(SurfNum).Tilt) - 180.0) > 1.0) {
+                                ++state.dataErrTracking
+                                      ->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::InterZoneSurfaceTiltMismatch)];
                                 ShowWarningError(state, std::format("{}InterZone Surface Tilts do not match as expected.", RoutineName));
                                 ShowContinueError(state,
                                                   std::format("  Tilt={:.1f} in Surface={}, Zone={}",
@@ -2039,6 +2043,8 @@ namespace SurfaceGeometry {
                                              180.0) > 1.0) {
                                     if (std::abs(state.dataSurface->Surface(SurfNum).SinTilt) > 0.5 || state.dataGlobal->DisplayExtraWarnings) {
                                         // if horizontal surfaces, then these are windows/doors/etc in those items.
+                                        ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(
+                                            DataErrorTracking::ErrorSummaryType::InterZoneSurfaceAzimuthMismatch)];
                                         ShowWarningError(state, std::format("{}InterZone Surface Azimuths do not match as expected.", RoutineName));
                                         ShowContinueError(state,
                                                           std::format("  Azimuth={:.1f}, Tilt={:.1f}, in Surface={}, Zone={}",
@@ -2819,6 +2825,7 @@ namespace SurfaceGeometry {
                 if (!state.dataConstruction->Construct(surf.Construction).TypeIsIRT) {
                     continue;
                 }
+                ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::InfraredTransparentUsage)];
                 if (!state.dataGlobal->DisplayExtraWarnings) {
                     ++iTmp1;
                 } else {
@@ -12948,6 +12955,7 @@ namespace SurfaceGeometry {
             Vectors::CalcCoPlanarNess(surf.Vertex, surf.Sides, IsCoPlanar, OutOfLine, LastVertexInError);
             if (!IsCoPlanar) {
                 if (OutOfLine > 0.01) {
+                    ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::NonPlanarSurfaces)];
                     ShowSevereError(state,
                                     std::format("{}Suspected non-planar surface:\"{}\", Max \"out of line\"={:.5f} at Vertex # {}",
                                                 RoutineName,

--- a/src/EnergyPlus/UnitarySystem.cc
+++ b/src/EnergyPlus/UnitarySystem.cc
@@ -8695,11 +8695,11 @@ namespace UnitarySystems {
             this->m_CoolingSpeedNum = SpeedNumEMS;
         }
         if (useMaxedSpeed) {
-            this->m_CoilSpeedErrIdx++;
+            int &coilSpeedErrIdx = state.dataUnitarySystems->HeatingLoad ? this->m_CoilSpeedErrIdxHeating : this->m_CoilSpeedErrIdxCooling;
             ShowRecurringWarningErrorAtEnd(state,
                                            "Wrong coil speed EMS override value, for unit=\"" + useMaxedSpeedCoilName +
                                                "\". Exceeding maximum coil speed level. Speed level is set to the maximum coil speed level allowed.",
-                                           this->m_CoilSpeedErrIdx,
+                                           coilSpeedErrIdx,
                                            this->m_EMSOverrideCoilSpeedNumValue,
                                            this->m_EMSOverrideCoilSpeedNumValue,
                                            _,
@@ -12630,12 +12630,11 @@ namespace UnitarySystems {
         }
         this->m_SuppHeatingSpeedNum = SpeedNumEMS;
         if (useMaxedSpeed) {
-            this->m_CoilSpeedErrIdx++;
             ShowRecurringWarningErrorAtEnd(state,
                                            std::format("Wrong coil speed EMS override value, for unit=\"{}\". Exceeding maximum coil speed "
                                                        "level. Speed level is set to the maximum coil speed level allowed.",
                                                        this->m_SuppHeatCoilName),
-                                           this->m_CoilSpeedErrIdx,
+                                           this->m_CoilSpeedErrIdxSuppHeat,
                                            this->m_EMSOverrideSuppCoilSpeedNumValue,
                                            this->m_EMSOverrideSuppCoilSpeedNumValue,
                                            _,
@@ -12845,7 +12844,7 @@ namespace UnitarySystems {
                         this->m_CoolingSpeedNum = this->m_NumOfSpeedCooling;
                         this->m_SpeedNum = this->m_NumOfSpeedCooling;
                         useMaxedSpeed = true;
-                        if (this->m_CoilSpeedErrIdx == 0) {
+                        if (this->m_CoilSpeedErrIdxCooling == 0) {
                             ShowWarningMessage(state, std::format("Wrong coil speed EMS override value, for unit=\"{}", this->m_CoolingCoilName));
                             ShowContinueError(state,
                                               "  Exceeding maximum coil speed level. Speed level is set to the maximum coil speed level allowed.");
@@ -12854,7 +12853,7 @@ namespace UnitarySystems {
                             state,
                             "Wrong coil speed EMS override value, for unit=\"" + this->m_CoolingCoilName +
                                 "\". Exceeding maximum coil speed level. Speed level is set to the maximum coil speed level allowed.",
-                            this->m_CoilSpeedErrIdx,
+                            this->m_CoilSpeedErrIdxCooling,
                             this->m_EMSOverrideCoilSpeedNumValue,
                             this->m_EMSOverrideCoilSpeedNumValue,
                             _,
@@ -12865,14 +12864,14 @@ namespace UnitarySystems {
                     if (this->m_SpeedNum < 0) {
                         this->m_CoolingSpeedNum = 0;
                         this->m_SpeedNum = 0;
-                        if (this->m_CoilSpeedErrIdx == 0) {
+                        if (this->m_CoilSpeedErrIdxCoolingBelowZero == 0) {
                             ShowWarningMessage(state, std::format("Wrong coil speed EMS override value, for unit=\"{}", this->m_CoolingCoilName));
                             ShowContinueError(state, "  Input speed value is below zero. Speed level is set to zero.");
                         }
                         ShowRecurringWarningErrorAtEnd(state,
                                                        "Wrong coil speed EMS override value, for unit=\"" + this->m_CoolingCoilName +
                                                            "\". Input speed value is below zero. Speed level is set to zero.",
-                                                       this->m_CoilSpeedErrIdx,
+                                                       this->m_CoilSpeedErrIdxCoolingBelowZero,
                                                        this->m_EMSOverrideCoilSpeedNumValue,
                                                        this->m_EMSOverrideCoilSpeedNumValue,
                                                        _,
@@ -14642,13 +14641,12 @@ namespace UnitarySystems {
                         if (this->m_SpeedNum > this->m_NumOfSpeedHeating) {
                             this->m_HeatingSpeedNum = this->m_NumOfSpeedHeating;
                             this->m_SpeedNum = this->m_NumOfSpeedHeating;
-                            this->m_CoilSpeedErrIdx++;
                             useMaxedSpeed = true;
                             ShowRecurringWarningErrorAtEnd(
                                 state,
                                 "Wrong coil speed EMS override value, for unit=\"" + this->m_HeatingCoilName +
                                     "\". Exceeding maximum coil speed level. Speed level is set to the maximum coil speed level allowed.",
-                                this->m_CoilSpeedErrIdx,
+                                this->m_CoilSpeedErrIdxHeating,
                                 this->m_EMSOverrideCoilSpeedNumValue,
                                 this->m_EMSOverrideCoilSpeedNumValue,
                                 _,

--- a/src/EnergyPlus/UnitarySystem.hh
+++ b/src/EnergyPlus/UnitarySystem.hh
@@ -389,7 +389,12 @@ namespace UnitarySystems {
         Real64 m_EMSOverrideCoilSpeedNumValue = 0.0;
         bool m_EMSOverrideSuppCoilSpeedNumOn = false;
         Real64 m_EMSOverrideSuppCoilSpeedNumValue = 0.0;
-        int m_CoilSpeedErrIdx = 0;
+        // Recurring "wrong EMS-overridden coil speed" warnings: one index per distinct message text
+        // (previously a single shared m_CoilSpeedErrIdx, which corrupted the "shown once" gating between messages)
+        int m_CoilSpeedErrIdxHeating = 0;
+        int m_CoilSpeedErrIdxCooling = 0;
+        int m_CoilSpeedErrIdxSuppHeat = 0;
+        int m_CoilSpeedErrIdxCoolingBelowZero = 0;
 
         Real64 m_DehumidInducedHeatingDemandRate = 0.0;
 

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1085,21 +1085,12 @@ void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Severe  ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    std::string const fullMessage = " ** Severe  ** " + Message;
+    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
+    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
 
     ++state.dataErrTracking->TotalSevereErrors;
-    StoreRecurringErrorMessage(
-        state, " ** Severe  ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
@@ -1132,20 +1123,12 @@ void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Severe  ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    std::string const fullMessage = " ** Severe  ** " + Message;
+    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
+    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
 
     ++state.dataErrTracking->TotalSevereErrors;
-    StoreRecurringErrorMessage(state, " ** Severe  ** " + Message, MsgIndex, val, val, _, units, units, "");
+    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, val, val, _, units, units, "");
 }
 
 void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
@@ -1182,21 +1165,12 @@ void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Warning ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    std::string const fullMessage = " ** Warning ** " + Message;
+    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
+    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
 
     ++state.dataErrTracking->TotalWarningErrors;
-    StoreRecurringErrorMessage(
-        state, " ** Warning ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
@@ -1229,20 +1203,12 @@ void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Warning ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    std::string const fullMessage = " ** Warning ** " + Message;
+    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
+    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
 
     ++state.dataErrTracking->TotalWarningErrors;
-    StoreRecurringErrorMessage(state, " ** Warning ** " + Message, MsgIndex, val, val, _, units, units, "");
+    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, val, val, _, units, units, "");
 }
 
 void ShowRecurringContinueErrorAtEnd(EnergyPlusData &state,
@@ -1279,20 +1245,11 @@ void ShowRecurringContinueErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " **   ~~~   ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    std::string const fullMessage = " **   ~~~   ** " + Message;
+    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
+    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
 
-    StoreRecurringErrorMessage(
-        state, " **   ~~~   ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void StoreRecurringErrorMessage(EnergyPlusData &state,
@@ -1323,6 +1280,7 @@ void StoreRecurringErrorMessage(EnergyPlusData &state,
         ErrorMsgIndex = state.dataErrTracking->NumRecurringErrors;
         // The message string only needs to be stored once when a new recurring message is created
         state.dataErrTracking->RecurringErrors(ErrorMsgIndex).Message = ErrorMessage;
+        state.dataErrTracking->RecurringErrorIndexByMessage[ErrorMessage] = ErrorMsgIndex;
         state.dataErrTracking->RecurringErrors(ErrorMsgIndex).Count = 1;
         if (state.dataGlobal->WarmupFlag) {
             state.dataErrTracking->RecurringErrors(ErrorMsgIndex).WarmupCount = 1;

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -100,8 +100,6 @@ namespace DataErrorTracking {
         // InterZoneSurfaceAreaMismatch
         {"InterZone Surface Areas -- mismatch",
          "Area mismatch errors happen when the interzone surface in zone A is<CR>not the same size as it's companion in zone B.<CRE>"},
-        // InterZoneSurfaceDifferentZones
-        {"Interzone surfaces - different zones", ""},
         // NodeConnectionErrors
         {"Node Connection Errors",
          "Node connection errors are often caused by spelling mistakes in a node name field.<CR>To track down the problem, search the idf file "
@@ -116,32 +114,11 @@ namespace DataErrorTracking {
         {"Likely non-planar surfaces",
          "EnergyPlus Surfaces should be planar. If the error indicates a small increment for the<CR>out of planar bounds, then the calculations "
          "are likely okay though you should try to fix<CR>the problem. If a greater increment, the calculations will likely be incorrect.<CRE>"},
-        // DeprecatedFeaturesOrKeyValues
-        {"Deprecated Features or Key Values",
-         "A deprecated feature warning/severe error indicates that you are using a feature which will be<CR>removed in a future release. The new "
-         "feature is likely included in the EnergyPlus version you are<CR>using.  Consider switching now to avoid future problems.<CR>A "
-         "deprecated key value message indicates you are using an out-dated key value in your input file.<CR>While EnergyPlus may continue to "
-         "accept these values, some other input file readers may not.<CR>Consider changing to values that are included as valid in the "
-         "Energy+.idd for these objects.<CRE>"},
-        // IncorrectFloorTilt
-        {"Incorrect Floor Tilt",
-         "Floors are usually flat and \"tilted\" 180 degrees.  If you get this error message,<CR>it's likely that you need to reverse the "
-         "vertices of the surface to remove the error.<CR>EnergyPlus will attempt to fix the vertices for the running simulation.<CR>You can "
-         "turn on the report: Output:Surfaces:List,Details; to inspect your surfaces.<CRE>"},
-        // IncorrectRoofCeilingTilt
-        {"Incorrect Roof/Ceiling Tilt",
-         "Flat roofs/ceilings are \"tilted\" 0 degrees. Pitched roofs should be \"near\" 0 degrees.<CR>If you get this error message, it's "
-         "likely that you need to reverse the vertices of<CR>the surface to remove the error. EnergyPlus will attempt to fix the vertices for "
-         "the<CR>running simulation. You can turn on the report: Output:Surfaces:List,Details;<CR>to inspect your surfaces.<CRE>"},
         // IncompleteViewFactors
         {"Incomplete View factors",
          "Incomplete view factors can result from incorrect floor specifications (such as tilting 0<CR>instead of 180) or not enough surfaces in "
          "a zone to make an enclosure.  The error message<CR>also shows an enforced reciprocity value.  You can decide if you need to make "
          "geometry<CR>changes based on that value.<CRE>"},
-        // UnbalancedExhaustAirFlow
-        {"Unbalanced exhaust air flow",
-         "Unbalanced exhaust air flow errors can occur when exhaust fans are running but there is no<CR>supply air. Turn off exhaust fans when "
-         "the system is not running may help resolve the problem.<CR>Time shown is first occurrence of error.<CRE>"},
         // LoadsInitializationDidNotConverge
         {"Loads Initialization did not Converge",
          "1) very high thermal mass such as very thick concrete (solution: increase max number of warmup<CR>   days in the BUILDING "
@@ -150,10 +127,6 @@ namespace DataErrorTracking {
          "properly controlled);<CR>3) a soil layer modeled below the concrete slab - (solution remove this layer and read about<CR>   ground "
          "temperatures in the Auxiliary Programs document).<CR>4) unreasonable (too small) limits in the BUILDING object for temperature (.4 "
          "default) or<CR>   loads tolerances (.04 default)<CRE>"},
-        // DaylightMapPointsNearWindow
-        {"CalcDaylightMapPoints: Window",
-         "Window is too close to map points for accurate calculation.  Suggested change is to create<CR>Output:IlluminanceMap coordinates "
-         "(x,y,z) that are more \"inside\" the zone<CRE>"},
         // ZoneAirHeatBalanceWarnings
         {"Zone Air Heat Balance Warnings",
          "Zone Air Heat Balance out of Balance warnings are currently used by developers.<CR>Users can safely ignore these warnings.<CRE>"},

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -86,16 +86,6 @@ extern "C" {
 #include <EnergyPlus/Timer.hh>
 #include <EnergyPlus/UtilityRoutines.hh>
 
-#ifndef NDEBUG
-#    ifndef DEBUG_MSG_INDEX
-#        define DEBUG_MSG_INDEX
-#    endif
-#endif
-
-#ifdef DEBUG_MSG_INDEX
-#    include <cassert>
-#endif
-
 namespace EnergyPlus {
 
 namespace DataErrorTracking {
@@ -1147,7 +1137,6 @@ void DetectIncorrectMsgIndex(EnergyPlusData &state, std::string const &lookup, i
             if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, lookup)) {
                 throw std::runtime_error(
                     std::format("ShowRecurringWarningErrorAtEnd called with MsgIndex=0 but message already exists in RecurringErrors:\n{}", lookup));
-                // assert(false && "ShowRecurringWarningErrorAtEnd called with MsgIndex=0 but message already exists in RecurringErrors");
             }
         }
     } else {
@@ -1160,8 +1149,6 @@ void DetectIncorrectMsgIndex(EnergyPlusData &state, std::string const &lookup, i
                             lookup,
                             state.dataErrTracking->RecurringErrors(MsgIndex).Message));
         }
-        assert(MsgIndex > 0 && MsgIndex <= state.dataErrTracking->NumRecurringErrors);
-        assert(Util::SameString(state.dataErrTracking->RecurringErrors(MsgIndex).Message, lookup));
     }
 }
 

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1105,14 +1105,7 @@ void ShowWarningMessage(EnergyPlusData &state, std::string const &ErrorMessage, 
 
 void DetectIncorrectMsgIndex(EnergyPlusData &state, std::string const &lookup, int &MsgIndex)
 {
-    if (MsgIndex == 0) {
-        for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-            if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, lookup)) {
-                throw std::runtime_error(
-                    std::format("ShowRecurringWarningErrorAtEnd called with MsgIndex=0 but message already exists in RecurringErrors:\n{}", lookup));
-            }
-        }
-    } else {
+    if (MsgIndex != 0) {
         if (MsgIndex < 1 || MsgIndex > state.dataErrTracking->NumRecurringErrors) {
             throw std::runtime_error(std::format("ShowRecurringWarningErrorAtEnd called with invalid MsgIndex:\n{}", lookup));
         }
@@ -1328,7 +1321,19 @@ void StoreRecurringErrorMessage(EnergyPlusData &state,
     // for output at the end of the simulation with automatic tracking of number
     // of occurrences and optional tracking of associated min, max, and sum values
 
-    // If Index is zero, then assign next available index and reallocate array
+    // If Index is zero, look for an existing identical message. This lookup is only paid once
+    // per correctly retained caller index, while allowing independent objects that emit the same
+    // generic message to share the recurring-error entry.
+    if (ErrorMsgIndex == 0) {
+        for (int loop = 1; loop <= state.dataErrTracking->NumRecurringErrors; ++loop) {
+            if (Util::SameString(state.dataErrTracking->RecurringErrors(loop).Message, ErrorMessage)) {
+                ErrorMsgIndex = loop;
+                break;
+            }
+        }
+    }
+
+    // If the message is new, assign the next available index and reallocate the array
     if (ErrorMsgIndex == 0) {
         state.dataErrTracking->RecurringErrors.redimension(++state.dataErrTracking->NumRecurringErrors);
         ErrorMsgIndex = state.dataErrTracking->NumRecurringErrors;

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1051,6 +1051,31 @@ void ShowWarningMessage(EnergyPlusData &state, std::string const &ErrorMessage, 
     }
 }
 
+void DetectIncorrectMsgIndex(EnergyPlusData &state, std::string const &lookup, int &MsgIndex)
+{
+    if (MsgIndex == 0) {
+        for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
+            if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, lookup)) {
+                throw std::runtime_error(
+                    std::format("ShowRecurringWarningErrorAtEnd called with MsgIndex=0 but message already exists in RecurringErrors:\n{}", lookup));
+                // assert(false && "ShowRecurringWarningErrorAtEnd called with MsgIndex=0 but message already exists in RecurringErrors");
+            }
+        }
+    } else {
+        if (MsgIndex < 1 || MsgIndex > state.dataErrTracking->NumRecurringErrors) {
+            throw std::runtime_error(std::format("ShowRecurringWarningErrorAtEnd called with invalid MsgIndex:\n{}", lookup));
+        }
+        if (!Util::SameString(state.dataErrTracking->RecurringErrors(MsgIndex).Message, lookup)) {
+            throw std::runtime_error(
+                std::format("ShowRecurringWarningErrorAtEnd called with MsgIndex that does not match the message:\nrequested: {}\nat index = {}",
+                            lookup,
+                            state.dataErrTracking->RecurringErrors(MsgIndex).Message));
+        }
+        assert(MsgIndex > 0 && MsgIndex <= state.dataErrTracking->NumRecurringErrors);
+        assert(Util::SameString(state.dataErrTracking->RecurringErrors(MsgIndex).Message, lookup));
+    }
+}
+
 void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
                                    std::string const &Message, // Message automatically written to "error file" at end of simulation
                                    int &MsgIndex,              // Recurring message index, if zero, next available index is assigned
@@ -1079,27 +1104,14 @@ void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
     //  Use for recurring "severe" error messages shown once at end of simulation
     //  with count of occurrences and optional max, min, sum
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(Message, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-            break;
-        }
-    }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Severe  ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    const std::string lookup = " ** Severe  ** " + Message;
+
+#ifdef DEBUG_MSG_INDEX
+    DetectIncorrectMsgIndex(state, lookup, MsgIndex);
+#endif
 
     ++state.dataErrTracking->TotalSevereErrors;
-    StoreRecurringErrorMessage(
-        state, " ** Severe  ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(state, lookup, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
@@ -1126,26 +1138,14 @@ void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
     //  Use for recurring "severe" error messages shown once at end of simulation
     //  with count of occurrences and optional max, min, sum
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(Message, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-            break;
-        }
-    }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Severe  ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    const std::string lookup = " ** Severe  ** " + Message;
+
+#ifdef DEBUG_MSG_INDEX
+    DetectIncorrectMsgIndex(state, lookup, MsgIndex);
+#endif
 
     ++state.dataErrTracking->TotalSevereErrors;
-    StoreRecurringErrorMessage(state, " ** Severe  ** " + Message, MsgIndex, val, val, _, units, units, "");
+    StoreRecurringErrorMessage(state, lookup, MsgIndex, val, val, _, units, units, "");
 }
 
 void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
@@ -1176,27 +1176,14 @@ void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
     //  Use for recurring "warning" error messages shown once at end of simulation
     //  with count of occurrences and optional max, min, sum
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(Message, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-            break;
-        }
-    }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Warning ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    const std::string lookup = " ** Warning ** " + Message;
+
+#ifdef DEBUG_MSG_INDEX
+    DetectIncorrectMsgIndex(state, lookup, MsgIndex);
+#endif
 
     ++state.dataErrTracking->TotalWarningErrors;
-    StoreRecurringErrorMessage(
-        state, " ** Warning ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(state, lookup, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
@@ -1223,26 +1210,14 @@ void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
     //  Use for recurring "warning" error messages shown once at end of simulation
     //  with count of occurrences and optional max, min, sum
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(Message, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-            break;
-        }
-    }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Warning ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    const std::string lookup = " ** Warning ** " + Message;
+
+#ifdef DEBUG_MSG_INDEX
+    DetectIncorrectMsgIndex(state, lookup, MsgIndex);
+#endif
 
     ++state.dataErrTracking->TotalWarningErrors;
-    StoreRecurringErrorMessage(state, " ** Warning ** " + Message, MsgIndex, val, val, _, units, units, "");
+    StoreRecurringErrorMessage(state, lookup, MsgIndex, val, val, _, units, units, "");
 }
 
 void ShowRecurringContinueErrorAtEnd(EnergyPlusData &state,
@@ -1273,26 +1248,13 @@ void ShowRecurringContinueErrorAtEnd(EnergyPlusData &state,
     //  Use for recurring "continue" error messages shown once at end of simulation
     //  with count of occurrences and optional max, min, sum
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(Message, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-            break;
-        }
-    }
-    bool bNewMessageFound = true;
-    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
-        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " **   ~~~   ** " + Message)) {
-            bNewMessageFound = false;
-            MsgIndex = Loop;
-            break;
-        }
-    }
-    if (bNewMessageFound) {
-        MsgIndex = 0;
-    }
+    const std::string lookup = " **   ~~~   ** " + Message;
 
-    StoreRecurringErrorMessage(
-        state, " **   ~~~   ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+#ifdef DEBUG_MSG_INDEX
+    DetectIncorrectMsgIndex(state, lookup, MsgIndex);
+#endif
+
+    StoreRecurringErrorMessage(state, lookup, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void StoreRecurringErrorMessage(EnergyPlusData &state,

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -1085,12 +1085,21 @@ void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    std::string const fullMessage = " ** Severe  ** " + Message;
-    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
-    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
+    bool bNewMessageFound = true;
+    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
+        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Severe  ** " + Message)) {
+            bNewMessageFound = false;
+            MsgIndex = Loop;
+            break;
+        }
+    }
+    if (bNewMessageFound) {
+        MsgIndex = 0;
+    }
 
     ++state.dataErrTracking->TotalSevereErrors;
-    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(
+        state, " ** Severe  ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
@@ -1123,12 +1132,20 @@ void ShowRecurringSevereErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    std::string const fullMessage = " ** Severe  ** " + Message;
-    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
-    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
+    bool bNewMessageFound = true;
+    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
+        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Severe  ** " + Message)) {
+            bNewMessageFound = false;
+            MsgIndex = Loop;
+            break;
+        }
+    }
+    if (bNewMessageFound) {
+        MsgIndex = 0;
+    }
 
     ++state.dataErrTracking->TotalSevereErrors;
-    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, val, val, _, units, units, "");
+    StoreRecurringErrorMessage(state, " ** Severe  ** " + Message, MsgIndex, val, val, _, units, units, "");
 }
 
 void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
@@ -1165,12 +1182,21 @@ void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    std::string const fullMessage = " ** Warning ** " + Message;
-    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
-    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
+    bool bNewMessageFound = true;
+    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
+        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Warning ** " + Message)) {
+            bNewMessageFound = false;
+            MsgIndex = Loop;
+            break;
+        }
+    }
+    if (bNewMessageFound) {
+        MsgIndex = 0;
+    }
 
     ++state.dataErrTracking->TotalWarningErrors;
-    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(
+        state, " ** Warning ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
@@ -1203,12 +1229,20 @@ void ShowRecurringWarningErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    std::string const fullMessage = " ** Warning ** " + Message;
-    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
-    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
+    bool bNewMessageFound = true;
+    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
+        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " ** Warning ** " + Message)) {
+            bNewMessageFound = false;
+            MsgIndex = Loop;
+            break;
+        }
+    }
+    if (bNewMessageFound) {
+        MsgIndex = 0;
+    }
 
     ++state.dataErrTracking->TotalWarningErrors;
-    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, val, val, _, units, units, "");
+    StoreRecurringErrorMessage(state, " ** Warning ** " + Message, MsgIndex, val, val, _, units, units, "");
 }
 
 void ShowRecurringContinueErrorAtEnd(EnergyPlusData &state,
@@ -1245,11 +1279,20 @@ void ShowRecurringContinueErrorAtEnd(EnergyPlusData &state,
             break;
         }
     }
-    std::string const fullMessage = " **   ~~~   ** " + Message;
-    auto const foundMsg = state.dataErrTracking->RecurringErrorIndexByMessage.find(fullMessage);
-    MsgIndex = (foundMsg != state.dataErrTracking->RecurringErrorIndexByMessage.end()) ? foundMsg->second : 0;
+    bool bNewMessageFound = true;
+    for (int Loop = 1; Loop <= state.dataErrTracking->NumRecurringErrors; ++Loop) {
+        if (Util::SameString(state.dataErrTracking->RecurringErrors(Loop).Message, " **   ~~~   ** " + Message)) {
+            bNewMessageFound = false;
+            MsgIndex = Loop;
+            break;
+        }
+    }
+    if (bNewMessageFound) {
+        MsgIndex = 0;
+    }
 
-    StoreRecurringErrorMessage(state, fullMessage, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
+    StoreRecurringErrorMessage(
+        state, " **   ~~~   ** " + Message, MsgIndex, ReportMaxOf, ReportMinOf, ReportSumOf, ReportMaxUnits, ReportMinUnits, ReportSumUnits);
 }
 
 void StoreRecurringErrorMessage(EnergyPlusData &state,
@@ -1280,7 +1323,6 @@ void StoreRecurringErrorMessage(EnergyPlusData &state,
         ErrorMsgIndex = state.dataErrTracking->NumRecurringErrors;
         // The message string only needs to be stored once when a new recurring message is created
         state.dataErrTracking->RecurringErrors(ErrorMsgIndex).Message = ErrorMessage;
-        state.dataErrTracking->RecurringErrorIndexByMessage[ErrorMessage] = ErrorMsgIndex;
         state.dataErrTracking->RecurringErrors(ErrorMsgIndex).Count = 1;
         if (state.dataGlobal->WarmupFlag) {
             state.dataErrTracking->RecurringErrors(ErrorMsgIndex).WarmupCount = 1;

--- a/src/EnergyPlus/UtilityRoutines.cc
+++ b/src/EnergyPlus/UtilityRoutines.cc
@@ -86,7 +86,120 @@ extern "C" {
 #include <EnergyPlus/Timer.hh>
 #include <EnergyPlus/UtilityRoutines.hh>
 
+#ifndef NDEBUG
+#    ifndef DEBUG_MSG_INDEX
+#        define DEBUG_MSG_INDEX
+#    endif
+#endif
+
+#ifdef DEBUG_MSG_INDEX
+#    include <cassert>
+#endif
+
 namespace EnergyPlus {
+
+namespace DataErrorTracking {
+
+    struct ErrorSummaryInfo
+    {
+        std::string_view Summary;
+        std::string_view MoreDetails;
+    };
+
+    static constexpr std::array<ErrorSummaryInfo, static_cast<size_t>(ErrorSummaryType::Num)> ErrorSummaries{{
+        // InterZoneSurfaceAreaMismatch
+        {"InterZone Surface Areas -- mismatch",
+         "Area mismatch errors happen when the interzone surface in zone A is<CR>not the same size as it's companion in zone B.<CRE>"},
+        // InterZoneSurfaceDifferentZones
+        {"Interzone surfaces - different zones", ""},
+        // NodeConnectionErrors
+        {"Node Connection Errors",
+         "Node connection errors are often caused by spelling mistakes in a node name field.<CR>To track down the problem, search the idf file "
+         "for each node name listed to see if it<CR>occurs in the expected input fields.<CRE>"},
+        // InterZoneSurfaceAzimuthMismatch
+        {"InterZone Surface Azimuths -- mismatch",
+         "The azimuths (outward facing angle) of two interzone surfaces should not be the same.<CR>Normally, the absolute difference between the "
+         "two azimuths will be 180 degrees.<CR>You can turn on the report: Output:Surfaces:List,Details; to inspect your surfaces.<CRE>"},
+        // InterZoneSurfaceTiltMismatch
+        {"InterZone Surface Tilts -- mismatch", ""},
+        // NonPlanarSurfaces
+        {"Likely non-planar surfaces",
+         "EnergyPlus Surfaces should be planar. If the error indicates a small increment for the<CR>out of planar bounds, then the calculations "
+         "are likely okay though you should try to fix<CR>the problem. If a greater increment, the calculations will likely be incorrect.<CRE>"},
+        // DeprecatedFeaturesOrKeyValues
+        {"Deprecated Features or Key Values",
+         "A deprecated feature warning/severe error indicates that you are using a feature which will be<CR>removed in a future release. The new "
+         "feature is likely included in the EnergyPlus version you are<CR>using.  Consider switching now to avoid future problems.<CR>A "
+         "deprecated key value message indicates you are using an out-dated key value in your input file.<CR>While EnergyPlus may continue to "
+         "accept these values, some other input file readers may not.<CR>Consider changing to values that are included as valid in the "
+         "Energy+.idd for these objects.<CRE>"},
+        // IncorrectFloorTilt
+        {"Incorrect Floor Tilt",
+         "Floors are usually flat and \"tilted\" 180 degrees.  If you get this error message,<CR>it's likely that you need to reverse the "
+         "vertices of the surface to remove the error.<CR>EnergyPlus will attempt to fix the vertices for the running simulation.<CR>You can "
+         "turn on the report: Output:Surfaces:List,Details; to inspect your surfaces.<CRE>"},
+        // IncorrectRoofCeilingTilt
+        {"Incorrect Roof/Ceiling Tilt",
+         "Flat roofs/ceilings are \"tilted\" 0 degrees. Pitched roofs should be \"near\" 0 degrees.<CR>If you get this error message, it's "
+         "likely that you need to reverse the vertices of<CR>the surface to remove the error. EnergyPlus will attempt to fix the vertices for "
+         "the<CR>running simulation. You can turn on the report: Output:Surfaces:List,Details;<CR>to inspect your surfaces.<CRE>"},
+        // IncompleteViewFactors
+        {"Incomplete View factors",
+         "Incomplete view factors can result from incorrect floor specifications (such as tilting 0<CR>instead of 180) or not enough surfaces in "
+         "a zone to make an enclosure.  The error message<CR>also shows an enforced reciprocity value.  You can decide if you need to make "
+         "geometry<CR>changes based on that value.<CRE>"},
+        // UnbalancedExhaustAirFlow
+        {"Unbalanced exhaust air flow",
+         "Unbalanced exhaust air flow errors can occur when exhaust fans are running but there is no<CR>supply air. Turn off exhaust fans when "
+         "the system is not running may help resolve the problem.<CR>Time shown is first occurrence of error.<CRE>"},
+        // LoadsInitializationDidNotConverge
+        {"Loads Initialization did not Converge",
+         "1) very high thermal mass such as very thick concrete (solution: increase max number of warmup<CR>   days in the BUILDING "
+         "object);<CR>2) moderate mass and inadequate space conditioning such that the building keeps getting warmer<CR>   and warmer on "
+         "successive days (solution: add HVAC, check building thermal properties,<CR>   check if infiltration is included, make sure HVAC "
+         "properly controlled);<CR>3) a soil layer modeled below the concrete slab - (solution remove this layer and read about<CR>   ground "
+         "temperatures in the Auxiliary Programs document).<CR>4) unreasonable (too small) limits in the BUILDING object for temperature (.4 "
+         "default) or<CR>   loads tolerances (.04 default)<CRE>"},
+        // DaylightMapPointsNearWindow
+        {"CalcDaylightMapPoints: Window",
+         "Window is too close to map points for accurate calculation.  Suggested change is to create<CR>Output:IlluminanceMap coordinates "
+         "(x,y,z) that are more \"inside\" the zone<CRE>"},
+        // ZoneAirHeatBalanceWarnings
+        {"Zone Air Heat Balance Warnings",
+         "Zone Air Heat Balance out of Balance warnings are currently used by developers.<CR>Users can safely ignore these warnings.<CRE>"},
+        // OccupantDensityExtremelyHigh
+        {"Occupant density is extremely high",
+         "The occupant density warning is provided to alert you to potential conditions that can cause<CR>problems with the heat balance "
+         "calculations. Too high a density could be cause for severe<CR>temperature out of bounds errors in a zone leading to program "
+         "termination.<CRE>"},
+        // TemperatureLowOutOfBounds
+        {"Temperature (low) out of bounds",
+         "A temperature out of bounds problem can be caused by several things. The user should check:<CR>1) the weather environment (including "
+         "the horizontal IR from sky)<CR>2) the level of internal gains with respect to the zone<CR>3) the thermal properties of their "
+         "materials.  And other things.<CR>A common cause is a building with no or little thermal mass - all materials with Material:NoMass "
+         "definitions.<CRE>"},
+        // TemperatureHighOutOfBounds
+        {"Temperature (high) out of bounds",
+         "A temperature out of bounds problem can be caused by several things. The user should check:<CR>1) the weather environment (including "
+         "the horizontal IR from sky)<CR>2) the level of internal gains with respect to the zone<CR>3) the thermal properties of their "
+         "materials.  And other things.<CR>A common cause is a building with no or little thermal mass - all materials with Material:NoMass "
+         "definitions.<CRE>"},
+        // NominallyUnusedConstructions
+        {"Nominally Unused Constructions",
+         "The nominally unused constructions warning is provided to alert you to potential conditions that can cause<CR>extra time during "
+         "simulation. Each construction is calculated by the algorithm indicated in the HeatBalanceAlgorithm<CR>object. You may remove the "
+         "constructions indicated (when you use the DisplayExtraWarnings option).<CRE>"},
+        // InfraredTransparentUsage
+        {"Material:InfraredTransparent usage",
+         "Using Material:InfraredTransparent materials in constructions are correctly used in interzone surface<CR>constructions. Warnings are "
+         "given if they are used in other kinds of surfaces.<CR>They CANNOT currently be used with ConductionFiniteDifference algorithms.<CRE>"},
+        // NoReportingElementsRequested
+        {"No Reporting Elements requested",
+         "No Reporting elements have been requested. You will see no output values from your run.<CR>Add Output:Variable, Output:Meter, "
+         "Output:Table:SummaryReports, Output:Table:Monthly, Output:Table:TimeBins<CR>objects to your input file to receive output values from "
+         "the simulation.<CRE>"},
+    }};
+} // namespace DataErrorTracking
 
 namespace Util {
 
@@ -804,12 +917,6 @@ void ShowSevereError(EnergyPlusData &state, std::string const &ErrorMessage, Opt
     // METHODOLOGY EMPLOYED:
     // Calls ShowErrorMessage utility routine.
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(ErrorMessage, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-        }
-    }
-
     ++state.dataErrTracking->TotalSevereErrors;
     if (state.dataGlobal->WarmupFlag && !state.dataGlobal->DoingSizing && !state.dataGlobal->KickOffSimulation &&
         !state.dataErrTracking->AbortProcessing) {
@@ -844,12 +951,6 @@ void ShowSevereMessage(EnergyPlusData &state, std::string const &ErrorMessage, O
 
     // METHODOLOGY EMPLOYED:
     // Calls ShowErrorMessage utility routine.
-
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(ErrorMessage, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-        }
-    }
 
     ShowErrorMessage(state, std::format(" ** Severe  ** {}", ErrorMessage), OutUnit1, OutUnit2);
     state.dataErrTracking->LastSevereError = ErrorMessage;
@@ -996,12 +1097,6 @@ void ShowWarningError(EnergyPlusData &state, std::string const &ErrorMessage, Op
     // METHODOLOGY EMPLOYED:
     // Calls ShowErrorMessage utility routine.
 
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(ErrorMessage, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-        }
-    }
-
     ++state.dataErrTracking->TotalWarningErrors;
     if (state.dataGlobal->WarmupFlag && !state.dataGlobal->DoingSizing && !state.dataGlobal->KickOffSimulation &&
         !state.dataErrTracking->AbortProcessing) {
@@ -1035,12 +1130,6 @@ void ShowWarningMessage(EnergyPlusData &state, std::string const &ErrorMessage, 
 
     // METHODOLOGY EMPLOYED:
     // Calls ShowErrorMessage utility routine.
-
-    for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-        if (has(ErrorMessage, DataErrorTracking::MessageSearch[Loop])) {
-            ++state.dataErrTracking->MatchCounts(Loop);
-        }
-    }
 
     ShowErrorMessage(state, std::format(" ** Warning ** {}", ErrorMessage), OutUnit1, OutUnit2);
     if (state.dataSQLiteProcedures->sqlite) {
@@ -1400,34 +1489,40 @@ void SummarizeErrors(EnergyPlusData &state)
     // This subroutine provides a summary of certain errors that might
     // otherwise get lost in the shuffle of many similar messages.
 
-    std::string::size_type StartC;
-    std::string::size_type EndC;
-
-    if (any_gt(state.dataErrTracking->MatchCounts, 0)) {
-        ShowMessage(state, "");
-        ShowMessage(state, "===== Final Error Summary =====");
-        ShowMessage(state, "The following error categories occurred.  Consider correcting or noting.");
-        for (int Loop = 1; Loop <= DataErrorTracking::SearchCounts; ++Loop) {
-            if (state.dataErrTracking->MatchCounts(Loop) > 0) {
-                ShowMessage(state, DataErrorTracking::Summaries[Loop]);
-                std::string thisMoreDetails = DataErrorTracking::MoreDetails[Loop];
-                if (!thisMoreDetails.empty()) {
-                    StartC = 0;
-                    EndC = len(thisMoreDetails) - 1;
-                    while (EndC != std::string::npos) {
-                        EndC = index(thisMoreDetails.substr(StartC), "<CR");
-                        ShowMessage(state, std::format("..{}", thisMoreDetails.substr(StartC, EndC)));
-                        if (thisMoreDetails.substr(StartC + EndC, 5) == "<CRE>") {
-                            break;
-                        }
-                        StartC += EndC + 4;
-                        EndC = len(thisMoreDetails.substr(StartC)) - 1;
-                    }
-                }
-            }
-        }
-        ShowMessage(state, "");
+    if (std::ranges::none_of(state.dataErrTracking->ErrorSummaryCount, [](int v) { return v > 0; })) {
+        return;
     }
+
+    ShowMessage(state, "");
+    ShowMessage(state, "===== Final Error Summary =====");
+    ShowMessage(state, "The following error categories occurred.  Consider correcting or noting.");
+
+    for (size_t i = 0; i < static_cast<size_t>(DataErrorTracking::ErrorSummaryType::Num); ++i) {
+        if (state.dataErrTracking->ErrorSummaryCount[i] == 0) {
+            continue;
+        }
+        const auto &error = DataErrorTracking::ErrorSummaries[i];
+        ShowMessage(state, std::string{error.Summary}); // TODO: address, ShowMessage and co should allow a string_view
+
+        const auto &thisMoreDetails = error.MoreDetails;
+        if (thisMoreDetails.empty()) {
+            continue;
+        }
+
+        std::string_view::size_type StartC = 0;
+        std::string_view::size_type EndC = thisMoreDetails.size() - 1;
+
+        while (EndC != std::string_view::npos) {
+            EndC = thisMoreDetails.substr(StartC).find("<CR");
+            ShowMessage(state, std::format("..{}", thisMoreDetails.substr(StartC, EndC)));
+            if (thisMoreDetails.substr(StartC + EndC, 5) == "<CRE>") {
+                break;
+            }
+            StartC += EndC + 4;
+            EndC = thisMoreDetails.substr(StartC).size() - 1;
+        }
+    }
+    ShowMessage(state, "");
 }
 
 void ShowRecurringErrors(EnergyPlusData &state)

--- a/src/EnergyPlus/ZoneTempPredictorCorrector.cc
+++ b/src/EnergyPlus/ZoneTempPredictorCorrector.cc
@@ -63,6 +63,7 @@
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataDefineEquip.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataHVACGlobals.hh>
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
@@ -5710,6 +5711,7 @@ void CalcZoneComponentLoadSums(EnergyPlusData &state,
                                            pow_2(thisAirRpt.CzdTdt));
         if ((std::abs(thisAirRpt.imBalance) > Threshold) && (!state.dataGlobal->WarmupFlag) &&
             (!state.dataGlobal->DoingSizing)) { // air balance is out by more than threshold
+            ++state.dataErrTracking->ErrorSummaryCount[static_cast<size_t>(DataErrorTracking::ErrorSummaryType::ZoneAirHeatBalanceWarnings)];
             if (thisZone.AirHBimBalanceErrIndex == 0) {
                 ShowWarningMessage(state, std::format("Zone Air Heat Balance is out of balance for zone named {}", thisZone.Name));
                 ShowContinueError(state, std::format("Zone Air Heat Balance Deviation Rate is more than {:.1f} {{W}}", Threshold));

--- a/tst/EnergyPlus/unit/HeatBalanceSurfaceManager.unit.cc
+++ b/tst/EnergyPlus/unit/HeatBalanceSurfaceManager.unit.cc
@@ -58,6 +58,7 @@
 #include <EnergyPlus/Data/EnergyPlusData.hh>
 #include <EnergyPlus/DataContaminantBalance.hh>
 #include <EnergyPlus/DataEnvironment.hh>
+#include <EnergyPlus/DataErrorTracking.hh>
 #include <EnergyPlus/DataGlobals.hh>
 #include <EnergyPlus/DataHeatBalFanSys.hh>
 #include <EnergyPlus/DataHeatBalSurface.hh>
@@ -231,11 +232,17 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceI
     EXPECT_TRUE(compare_err_stream(error_string01, true));
     EXPECT_TRUE(testZone.TempOutOfBoundsReported);
 
+    auto forceReissuingCompleteErrorMessages = [this]() {
+        state->dataErrTracking->NumRecurringErrors = 0;
+        state->dataErrTracking->RecurringErrors.clear();
+        state->dataSurface->SurfLowTempErrCount(1) = 0;
+        state->dataSurface->SurfHighTempErrCount(1) = 0;
+    };
+
     // to hot - subsequent times
     surfTemp = 201;
     state->dataGlobal->WarmupFlag = false;
-    state->dataSurface->SurfLowTempErrCount(1) = 0;
-    state->dataSurface->SurfHighTempErrCount(1) = 0;
+    forceReissuingCompleteErrorMessages();
     testZone.TempOutOfBoundsReported = true;
     testZone.FloorArea = 1000;
     testZone.IsControlled = true;
@@ -250,8 +257,7 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceI
     // to cold - first time
     surfTemp = -101;
     state->dataGlobal->WarmupFlag = false;
-    state->dataSurface->SurfLowTempErrCount(1) = 0;
-    state->dataSurface->SurfHighTempErrCount(1) = 0;
+    forceReissuingCompleteErrorMessages();
     testZone.TempOutOfBoundsReported = false;
     testZone.FloorArea = 1000;
     testZone.IsControlled = true;
@@ -270,8 +276,7 @@ TEST_F(EnergyPlusFixture, HeatBalanceSurfaceManager_TestSurfTempCalcHeatBalanceI
     // to cold - subsequent times
     surfTemp = -101;
     state->dataGlobal->WarmupFlag = false;
-    state->dataSurface->SurfLowTempErrCount(1) = 0;
-    state->dataSurface->SurfHighTempErrCount(1) = 0;
+    forceReissuingCompleteErrorMessages();
     testZone.TempOutOfBoundsReported = true;
     testZone.FloorArea = 1000;
     testZone.IsControlled = true;

--- a/tst/EnergyPlus/unit/PlantLoopHeatPumpEIR.unit.cc
+++ b/tst/EnergyPlus/unit/PlantLoopHeatPumpEIR.unit.cc
@@ -3454,6 +3454,15 @@ TEST_F(EnergyPlusFixture, TestConcurrentOperationChecking)
     EIRPlantLoopHeatPump *coil3 = &state->dataEIRPlantLoopHeatPump->heatPumps[2];
     EIRPlantLoopHeatPump *coil4 = &state->dataEIRPlantLoopHeatPump->heatPumps[3];
 
+    // give them distinct names -- GetInput guarantees uniqueness for real objects, and the
+    // concurrent-operation warning text embeds the coil's own name, so two coils sharing a
+    // (default-empty) name here would produce identical message text, which isn't representative
+    // of any real input file.
+    coil1->name = "COIL 1";
+    coil2->name = "COIL 2";
+    coil3->name = "COIL 3";
+    coil4->name = "COIL 4";
+
     // pair up the last two
     coil3->companionHeatPumpCoil = coil4;
     coil4->companionHeatPumpCoil = coil3;
@@ -3472,7 +3481,7 @@ TEST_F(EnergyPlusFixture, TestConcurrentOperationChecking)
     ASSERT_EQ(0, coil1->recurringConcurrentOperationWarningIndex);
     ASSERT_EQ(0, coil2->recurringConcurrentOperationWarningIndex);
     ASSERT_EQ(1, coil3->recurringConcurrentOperationWarningIndex);
-    ASSERT_EQ(1, coil4->recurringConcurrentOperationWarningIndex);
+    ASSERT_EQ(2, coil4->recurringConcurrentOperationWarningIndex);
 }
 
 TEST_F(EnergyPlusFixture, ConstructionFullObjectsHeatingAndCooling_AirSource)

--- a/tst/EnergyPlus/unit/Psychrometrics.unit.cc
+++ b/tst/EnergyPlus/unit/Psychrometrics.unit.cc
@@ -247,6 +247,10 @@ TEST_F(EnergyPlusFixture, Psychrometrics_PsyWFnTdpPb_Test)
         "   **   ~~~   **  Dew-Point= 100.00 Barometric Pressure= 81000.00",
         "   **   ~~~   ** Instead, calculated Humidity Ratio at 93.0 (7 degree less) = 20.0794 will be used. Simulation continues.",
     });
+
+    // Force to print the full detailed warning message for the next call to PsyWFnTdpPb
+    state->dataErrTracking->NumRecurringErrors = 0;
+    state->dataErrTracking->RecurringErrors.clear();
     state->dataPsychrometrics->iPsyErrIndex[static_cast<int>(PsychrometricFunction::WFnTdpPb)] = 0;
 
     W = Psychrometrics::PsyWFnTdpPb(*state, TDP, PB);

--- a/tst/EnergyPlus/unit/UtilityRoutines.unit.cc
+++ b/tst/EnergyPlus/unit/UtilityRoutines.unit.cc
@@ -102,6 +102,14 @@ TEST_F(EnergyPlusFixture, RecurringWarningTest)
     EXPECT_EQ(" ** Warning ** " + myMessage2, state->dataErrTracking->RecurringErrors(ErrIndex2).Message);
     EXPECT_EQ(2, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
 
+    // Independent callers can own separate index variables while emitting the same generic
+    // message. The second zero index should reuse the existing recurring-error entry.
+    int ErrIndex2FromAnotherCaller = 0;
+    ShowRecurringWarningErrorAtEnd(*state, myMessage2, ErrIndex2FromAnotherCaller);
+    EXPECT_EQ(ErrIndex2, ErrIndex2FromAnotherCaller);
+    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(3, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
+
     // same message for different show message type (changed severe to warning) should result in an addition
     std::string myMessage3 = "Test message 3";
     int ErrIndex3AsError = 0;
@@ -129,13 +137,9 @@ TEST_F(EnergyPlusFixture, RecurringWarningTest)
     // improper call to ShowRecurringWarningErrorAtEnd: the Index exists, but the message doesn't match
     EXPECT_ANY_THROW(ShowRecurringWarningErrorAtEnd(*state, myMessage2, ErrIndex1));
 
-    // improper call to ShowRecurringWarningErrorAtEnd: index is passed as 0, but the message already exists in the array
-    int ZeroIndex = 0;
-    EXPECT_ANY_THROW(ShowRecurringWarningErrorAtEnd(*state, myMessage2, ZeroIndex));
-
     EXPECT_EQ(4, state->dataErrTracking->RecurringErrors.size());
     EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex1).Count);
-    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
+    EXPECT_EQ(3, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
     EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex3AsError).Count);
     EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex3AsWarning).Count);
 #endif

--- a/tst/EnergyPlus/unit/UtilityRoutines.unit.cc
+++ b/tst/EnergyPlus/unit/UtilityRoutines.unit.cc
@@ -82,48 +82,63 @@ TEST_F(EnergyPlusFixture, RecurringWarningTest)
     // proper call to ShowRecurringWarningErrorAtEnd to set up new recurring warning
     int ErrIndex1 = 0;
     ShowRecurringWarningErrorAtEnd(*state, myMessage1, ErrIndex1);
-    EXPECT_EQ(ErrIndex1, 1);
-    EXPECT_EQ(state->dataErrTracking->RecurringErrors.size(), 1u);
-    EXPECT_EQ(" ** Warning ** " + myMessage1, state->dataErrTracking->RecurringErrors(1).Message);
-    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(1).Count);
+    EXPECT_EQ(1, ErrIndex1);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(" ** Warning ** " + myMessage1, state->dataErrTracking->RecurringErrors(ErrIndex1).Message);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex1).Count);
 
     std::string myMessage2 = "Test message 2";
-    // improper call to ShowRecurringWarningErrorAtEnd to set up new recurring warning
-    int ErrIndex2 = 6;
+    int ErrIndex2 = 0;
     ShowRecurringWarningErrorAtEnd(*state, myMessage2, ErrIndex2);
-    EXPECT_EQ(ErrIndex2, 2); // ShowRecurringWarningErrorAtEnd handles improper index and returns correct value
-    EXPECT_EQ(state->dataErrTracking->RecurringErrors.size(), 2u);
-    EXPECT_EQ(" ** Warning ** " + myMessage2, state->dataErrTracking->RecurringErrors(2).Message);
-    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(2).Count);
+    EXPECT_EQ(2, ErrIndex2);
+    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(" ** Warning ** " + myMessage2, state->dataErrTracking->RecurringErrors(ErrIndex2).Message);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
 
-    ErrIndex2 = 6;
+    // Passing the already existing index
     ShowRecurringWarningErrorAtEnd(*state, myMessage2, ErrIndex2);
-    EXPECT_EQ(ErrIndex2, 2); // ShowRecurringWarningErrorAtEnd handles improper index and returns correct value
-    EXPECT_EQ(state->dataErrTracking->RecurringErrors.size(), 2u);
-    EXPECT_EQ(" ** Warning ** " + myMessage2, state->dataErrTracking->RecurringErrors(2).Message);
-    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors(2).Count);
+    EXPECT_EQ(2, ErrIndex2); // Stays the same
+    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(" ** Warning ** " + myMessage2, state->dataErrTracking->RecurringErrors(ErrIndex2).Message);
+    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
 
+    // same message for different show message type (changed severe to warning) should result in an addition
     std::string myMessage3 = "Test message 3";
-    ShowRecurringContinueErrorAtEnd(*state, myMessage3, ErrIndex1);
+    int ErrIndex3AsError = 0;
+    ShowRecurringSevereErrorAtEnd(*state, myMessage3, ErrIndex3AsError);
     // index gets updated with correct value
-    EXPECT_EQ(ErrIndex1, 3);
-    EXPECT_EQ(state->dataErrTracking->RecurringErrors.size(), 3u);
-    EXPECT_EQ(" **   ~~~   ** " + myMessage3, state->dataErrTracking->RecurringErrors(3).Message);
-    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(3).Count);
+    EXPECT_EQ(3, ErrIndex3AsError);
+    EXPECT_EQ(3, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(" ** Severe  ** " + myMessage3, state->dataErrTracking->RecurringErrors(ErrIndex3AsError).Message);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex3AsError).Count);
 
-    std::string myMessage4 = "Test message 4";
-    ShowRecurringSevereErrorAtEnd(*state, myMessage4, ErrIndex1);
+    int ErrIndex3AsWarning = 0;
+    ShowRecurringWarningErrorAtEnd(*state, myMessage3, ErrIndex3AsWarning);
     // index gets updated with correct value
-    EXPECT_EQ(ErrIndex1, 4);
-    EXPECT_EQ(state->dataErrTracking->RecurringErrors.size(), 4u);
-    EXPECT_EQ(" ** Severe  ** " + myMessage4, state->dataErrTracking->RecurringErrors(4).Message);
-    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(4).Count);
+    EXPECT_EQ(4, ErrIndex3AsWarning);
+    EXPECT_EQ(4, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(" ** Warning ** " + myMessage3, state->dataErrTracking->RecurringErrors(ErrIndex3AsWarning).Message);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex3AsWarning).Count);
 
-    // same message for different show message type (changed severe to warning) should be valid
-    ShowRecurringWarningErrorAtEnd(*state, myMessage4, ErrIndex1);
-    // index gets updated with correct value
-    EXPECT_EQ(ErrIndex1, 5);
-    EXPECT_EQ(" ** Warning ** " + myMessage4, state->dataErrTracking->RecurringErrors(5).Message);
+#ifdef DEBUG_MSG_INDEX
+    // improper call to ShowRecurringWarningErrorAtEnd
+    // The Index doesn't even exist in the array
+    int WrongIndex = 6;
+    EXPECT_ANY_THROW(ShowRecurringWarningErrorAtEnd(*state, myMessage2, WrongIndex));
+
+    // improper call to ShowRecurringWarningErrorAtEnd: the Index exists, but the message doesn't match
+    EXPECT_ANY_THROW(ShowRecurringWarningErrorAtEnd(*state, myMessage2, ErrIndex1));
+
+    // improper call to ShowRecurringWarningErrorAtEnd: index is passed as 0, but the message already exists in the array
+    int ZeroIndex = 0;
+    EXPECT_ANY_THROW(ShowRecurringWarningErrorAtEnd(*state, myMessage2, ZeroIndex));
+
+    EXPECT_EQ(4, state->dataErrTracking->RecurringErrors.size());
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex1).Count);
+    EXPECT_EQ(2, state->dataErrTracking->RecurringErrors(ErrIndex2).Count);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex3AsError).Count);
+    EXPECT_EQ(1, state->dataErrTracking->RecurringErrors(ErrIndex3AsWarning).Count);
+#endif
 }
 
 TEST_F(EnergyPlusFixture, DisplayMessageTest)


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #11773 


Using a pathological model (40million warnings): [in_26.2.idf](https://github.com/NatLabRockies/EnergyPlusDevSupport/blob/master/DefectFiles/11000s/11753/in_26.2.idf) from https://github.com/NatLabRockies/EnergyPlus/issues/11753

| Metric | Before | After | Abs. Gain | % Gain | Speedup |
|---|---:|---:|---:|---:|---:|
| Real time | 8m 37.182s | 7m 9.279s | 87.903s | 17.00% | 1.205× |


### Description of the purpose of this PR

- For SummarizeErrors, move the iteration at the point of call instead of paying the cost of comparing every "Message" passed in any of the ShowMessage / ShowRecurring functions against 20 strings
- For ShowRecurring, it was already checking every recurring message regardless of whether we passes a MsgIndex of 0 or not. It was "self-healing" but awfully inefficient.
    - Now we pass a MsgIndex and just **trust** it, avoiding these expensive checks
         - If 0, a new one is computed, without checking if it already exists in the existing recurring error messages
         - If non zero, then we just **reuse** it
    - I had to fix a lot of calling sites: all the broken occurences where the `MsgIndex` (usually stored on the struct....) was either reused for different messages, not assigned, or even manually incremented (?!)
    - And to make it more robust, in Debug mode, or when a new advanced cmake variable FORCE_DEBUG_MSG_INDEX is ON, it will still do the old expensive checks and **throw** if the precondition (=trust) is violated.

Locally I ran tests with develop. and I tests with this branch with FORCE_DEBUG_MSG_INDEX. I then analyzed the regressions, and everything checks out. Tests pass, and there is a single diff, which is an improvement: it no longer issues the SAME warning twice.

```
$ cat regressions/HybridZoneModel/eplusout.err.diff
--- 
+++ 
@@ -7,9 +7,6 @@
    ************* All Return Air Paths passed integrity testing
    ************* No node connection errors were found.
    ************* Beginning Simulation
-   ** Warning ** Hybrid model thermal mass multiplier higher than the limit for ZONE 1
-   **   ~~~   ** This means that the ratio of the zone air heat capacity for the current time step to the
-   **   ~~~   ** zone air heat storage is higher than the maximum limit of 30.0.
    ** Warning ** Hybrid model thermal mass multiplier higher than the limit for ZONE 1
    **   ~~~   ** This means that the ratio of the zone air heat capacity for the current time step to the
    **   ~~~   ** zone air heat storage is higher than the maximum limit of 30.0.
```

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
