### PR TITLE
Update `RevisePlantCallingOrder` to preserve plant loop demand-before-supply ordering

### DIFF
--- a/src/EnergyPlus/Plant/PlantManager.cc
+++ b/src/EnergyPlus/Plant/PlantManager.cc
@@ -3611,124 +3611,81 @@ void RevisePlantCallingOrder(EnergyPlusData &state)
     // SUBROUTINE INFORMATION:
     //       AUTHOR         Brent Griffith
     //       DATE WRITTEN   April 2011
-    //       MODIFIED       na
-    //       RE-ENGINEERED  Sept. 2026 Joe Robertson
+    //       MODIFIED       Sept. 2026 Joe Robertson
+    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS SUBROUTINE:
-    // Choose the order in which plant loop sides are called. A loop that supplies another loop must be
-    // called first so that the receiving loop sees current conditions. For example, if Loop A supplies
-    // Loop B, the order should be A followed by B, regardless of their order in the input file.
+    // Setup the order that plant loop sides are to be called while preserving demand-before-supply for each loop.
 
     // METHODOLOGY EMPLOYED:
-    // The previous method moved entries around in the existing calling-order list as it examined connections.
-    // Because that list followed input order, two otherwise identical input files could produce different results.
-    // The current method treats each loop side as a point in a dependency graph. For example, A -> B means
-    // "call A before B." It also adds Demand -> Supply for every loop, then repeatedly selects an eligible
-    // loop side using loop name and side as stable tie-breakers. If the dependencies say A -> B -> A, the
-    // requirements form a cycle and no perfect order exists; the unresolved sides are placed using the same
-    // stable tie-breakers.
+    // Start with the demand-before-supply order established by SetupInitialPlantCallingOrder, then rearrange
+    // loop sides to account for interconnected components. Existing interconnection rules also avoid moving a
+    // supply side before its own demand side. Because later shifts can otherwise disturb that relationship,
+    // restore demand-before-supply for every loop after processing the interconnections.
 
-    struct HalfLoopNode
-    {
-        int loopNum;
-        DataPlant::LoopSideLocation loopSide;
-    };
+    // Using/Aliasing
+    using PlantUtilities::ShiftPlantLoopSideCallingOrder;
 
-    std::vector<HalfLoopNode> nodes;
-    nodes.reserve(state.dataPlnt->TotNumHalfLoops);
-    for (int loopNum = 1; loopNum <= state.dataPlnt->TotNumLoops; ++loopNum) {
-        nodes.push_back({loopNum, LoopSideLocation::Demand});
-        nodes.push_back({loopNum, LoopSideLocation::Supply});
-    }
+    // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
+    DataPlant::LoopSideLocation LoopSideNum;
+    DataPlant::LoopSideLocation OtherLoopSideNum;
 
-    auto nodeLess = [&](int lhs, int rhs) {
-        auto const &lhsNode = nodes[lhs];
-        auto const &rhsNode = nodes[rhs];
-        auto const &lhsName = state.dataPlnt->PlantLoop(lhsNode.loopNum).Name;
-        auto const &rhsName = state.dataPlnt->PlantLoop(rhsNode.loopNum).Name;
-        if (lhsName != rhsName) {
-            return lhsName < rhsName;
-        }
-        if (lhsNode.loopSide != rhsNode.loopSide) {
-            return lhsNode.loopSide == LoopSideLocation::Demand;
-        }
-        return lhsNode.loopNum < rhsNode.loopNum;
-    };
+    bool thisLoopPutsDemandOnAnother;
+    int ConnctNum;
 
-    auto findNode = [&](int loopNum, DataPlant::LoopSideLocation loopSide) {
-        return static_cast<int>(
-            std::find_if(nodes.begin(), nodes.end(), [&](auto const &node) { return node.loopNum == loopNum && node.loopSide == loopSide; }) -
-            nodes.begin());
-    };
+    for (int HalfLoopNum = 1; HalfLoopNum <= state.dataPlnt->TotNumHalfLoops; ++HalfLoopNum) {
 
-    std::vector<std::vector<int>> successors(nodes.size());
-    std::vector<int> indegree(nodes.size(), 0);
-    auto addDependency = [&](int before, int after) {
-        auto &successorList = successors[before];
-        if (std::find(successorList.begin(), successorList.end(), after) == successorList.end()) {
-            successorList.push_back(after);
-            ++indegree[after];
-        }
-    };
+        int LoopNum = state.dataPlnt->PlantCallingOrderInfo(HalfLoopNum).LoopIndex;
+        LoopSideNum = state.dataPlnt->PlantCallingOrderInfo(HalfLoopNum).LoopSide;
 
-    for (int loopNum = 1; loopNum <= state.dataPlnt->TotNumLoops; ++loopNum) {
-        addDependency(findNode(loopNum, LoopSideLocation::Demand), findNode(loopNum, LoopSideLocation::Supply));
-        for (auto loopSide : {LoopSideLocation::Demand, LoopSideLocation::Supply}) {
-            auto const &connections = state.dataPlnt->PlantLoop(loopNum).LoopSide(loopSide).Connected;
-            if (!allocated(connections)) {
-                continue;
-            }
-            for (int connectionNum = 1; connectionNum <= isize(connections); ++connectionNum) {
-                auto const &connection = connections(connectionNum);
-                int currentNode = findNode(loopNum, loopSide);
-                int remoteNode = findNode(connection.LoopNum, connection.LoopSideNum);
-                if (connection.LoopDemandsOnRemote) {
-                    addDependency(currentNode, remoteNode);
-                } else {
-                    addDependency(remoteNode, currentNode);
+        if (allocated(state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected)) {
+            for (ConnctNum = 1; ConnctNum <= isize(state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected); ++ConnctNum) {
+                int OtherLoopNum = state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected(ConnctNum).LoopNum;
+                OtherLoopSideNum = state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected(ConnctNum).LoopSideNum;
+                state.dataPlantMgr->OtherLoopCallingIndex = FindLoopSideInCallingOrder(state, OtherLoopNum, OtherLoopSideNum);
+
+                thisLoopPutsDemandOnAnother = state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected(ConnctNum).LoopDemandsOnRemote;
+                if (thisLoopPutsDemandOnAnother) {                                 // make sure this loop side is called before the other loop side
+                    if (state.dataPlantMgr->OtherLoopCallingIndex < HalfLoopNum) { // rearrange
+                        state.dataPlantMgr->newCallingIndex = min(HalfLoopNum + 1, state.dataPlnt->TotNumHalfLoops);
+                        ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
+                    }
+
+                } else {                                                           // make sure the other is called before this one
+                    if (state.dataPlantMgr->OtherLoopCallingIndex > HalfLoopNum) { // rearrange
+                        state.dataPlantMgr->newCallingIndex = max(HalfLoopNum, 1);
+
+                        if (OtherLoopSideNum == LoopSideLocation::Supply) { // if this is a supply side, don't push it before its own demand side
+                            state.dataPlantMgr->OtherLoopDemandSideCallingIndex =
+                                FindLoopSideInCallingOrder(state, OtherLoopNum, LoopSideLocation::Demand);
+                            if (state.dataPlantMgr->OtherLoopDemandSideCallingIndex < HalfLoopNum) { // good to go
+                                state.dataPlantMgr->newCallingIndex = min(state.dataPlantMgr->OtherLoopDemandSideCallingIndex + 1,
+                                                                          state.dataPlnt->TotNumHalfLoops); // put it right after its demand side
+                                ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
+                            } else { // move both sides of other loop before this, keeping demand side in front
+                                state.dataPlantMgr->NewOtherDemandSideCallingIndex = max(HalfLoopNum, 1);
+                                ShiftPlantLoopSideCallingOrder(
+                                    state, state.dataPlantMgr->OtherLoopDemandSideCallingIndex, state.dataPlantMgr->NewOtherDemandSideCallingIndex);
+                                // get fresh pointer after it has changed in previous call
+                                state.dataPlantMgr->OtherLoopCallingIndex = FindLoopSideInCallingOrder(state, OtherLoopNum, OtherLoopSideNum);
+                                state.dataPlantMgr->newCallingIndex = state.dataPlantMgr->NewOtherDemandSideCallingIndex + 1;
+                                ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
+                            }
+                        } else {
+                            ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
+                        }
+                    }
                 }
             }
         }
     }
 
-    std::vector<int> ready;
-    for (int node = 0; node < static_cast<int>(nodes.size()); ++node) {
-        if (indegree[node] == 0) {
-            ready.push_back(node);
+    for (int loopNum = 1; loopNum <= state.dataPlnt->TotNumLoops; ++loopNum) {
+        int demandIndex = FindLoopSideInCallingOrder(state, loopNum, LoopSideLocation::Demand);
+        int supplyIndex = FindLoopSideInCallingOrder(state, loopNum, LoopSideLocation::Supply);
+        if (demandIndex > supplyIndex) {
+            ShiftPlantLoopSideCallingOrder(state, demandIndex, supplyIndex);
         }
-    }
-
-    std::vector<int> revisedOrder;
-    revisedOrder.reserve(nodes.size());
-    while (!ready.empty()) {
-        std::sort(ready.begin(), ready.end(), nodeLess);
-        int node = ready.front();
-        ready.erase(ready.begin());
-        revisedOrder.push_back(node);
-        for (int successor : successors[node]) {
-            if (--indegree[successor] == 0) {
-                ready.push_back(successor);
-            }
-        }
-    }
-
-    if (revisedOrder.size() != nodes.size()) {
-        ShowWarningError(state,
-                         "PlantManager: plant loop calling-order dependencies contain a cycle; using canonical order for unresolved loop sides.");
-        std::vector<int> unresolved;
-        for (int node = 0; node < static_cast<int>(nodes.size()); ++node) {
-            if (std::find(revisedOrder.begin(), revisedOrder.end(), node) == revisedOrder.end()) {
-                unresolved.push_back(node);
-            }
-        }
-        std::sort(unresolved.begin(), unresolved.end(), nodeLess);
-        revisedOrder.insert(revisedOrder.end(), unresolved.begin(), unresolved.end());
-    }
-
-    for (int order = 0; order < static_cast<int>(revisedOrder.size()); ++order) {
-        auto const &node = nodes[revisedOrder[order]];
-        state.dataPlnt->PlantCallingOrderInfo(order + 1).LoopIndex = node.loopNum;
-        state.dataPlnt->PlantCallingOrderInfo(order + 1).LoopSide = node.loopSide;
     }
 }
 

--- a/src/EnergyPlus/Plant/PlantManager.cc
+++ b/src/EnergyPlus/Plant/PlantManager.cc
@@ -49,6 +49,7 @@
 #include <algorithm>
 #include <cassert>
 #include <format>
+#include <vector>
 
 // ObjexxFCL Headers
 #include <ObjexxFCL/Array.functions.hh>
@@ -3611,70 +3612,110 @@ void RevisePlantCallingOrder(EnergyPlusData &state)
     //       AUTHOR         Brent Griffith
     //       DATE WRITTEN   April 2011
     //       MODIFIED       na
-    //       RE-ENGINEERED  na
+    //       RE-ENGINEERED  Sept. 2026 Joe Robertson
 
     // PURPOSE OF THIS SUBROUTINE:
-    // setup the order that plant loops are to be called
+    // Choose the order in which plant loop sides are called. A loop that supplies another loop must be
+    // called first so that the receiving loop sees current conditions. For example, if Loop A supplies
+    // Loop B, the order should be A followed by B, regardless of their order in the input file.
 
     // METHODOLOGY EMPLOYED:
-    // simple rule-based allocation of which order to call the half loops
-    // Examine for interconnected components and rearrange to impose the following rules
+    // The previous method moved entries around in the existing calling-order list as it examined connections.
+    // Because that list followed input order, two otherwise identical input files could produce different results.
+    // The current method treats each loop side as a point in a dependency graph. For example, A -> B means
+    // "call A before B." It also adds Demand -> Supply for every loop, then repeatedly selects an eligible
+    // loop side using loop name and side as stable tie-breakers. If the dependencies say A -> B -> A, the
+    // requirements form a cycle and no perfect order exists; the unresolved sides are placed using the same
+    // stable tie-breakers.
 
-    // Using/Aliasing
-    using PlantUtilities::ShiftPlantLoopSideCallingOrder;
+    struct HalfLoopNode
+    {
+        int loopNum;
+        DataPlant::LoopSideLocation loopSide;
+    };
 
-    // SUBROUTINE LOCAL VARIABLE DECLARATIONS:
-    DataPlant::LoopSideLocation LoopSideNum;
-    DataPlant::LoopSideLocation OtherLoopSideNum;
+    std::vector<HalfLoopNode> nodes;
+    nodes.reserve(state.dataPlnt->TotNumHalfLoops);
+    for (int loopNum = 1; loopNum <= state.dataPlnt->TotNumLoops; ++loopNum) {
+        nodes.push_back({loopNum, LoopSideLocation::Demand});
+        nodes.push_back({loopNum, LoopSideLocation::Supply});
+    }
 
-    bool thisLoopPutsDemandOnAnother;
-    int ConnctNum;
+    auto nodeLess = [&](int lhs, int rhs) {
+        auto const &lhsNode = nodes[lhs];
+        auto const &rhsNode = nodes[rhs];
+        auto const &lhsName = state.dataPlnt->PlantLoop(lhsNode.loopNum).Name;
+        auto const &rhsName = state.dataPlnt->PlantLoop(rhsNode.loopNum).Name;
+        if (lhsName != rhsName) return lhsName < rhsName;
+        if (lhsNode.loopSide != rhsNode.loopSide) return lhsNode.loopSide == LoopSideLocation::Demand;
+        return lhsNode.loopNum < rhsNode.loopNum;
+    };
 
-    for (int HalfLoopNum = 1; HalfLoopNum <= state.dataPlnt->TotNumHalfLoops; ++HalfLoopNum) {
+    auto findNode = [&](int loopNum, DataPlant::LoopSideLocation loopSide) {
+        return static_cast<int>(std::find_if(nodes.begin(), nodes.end(), [&](auto const &node) {
+            return node.loopNum == loopNum && node.loopSide == loopSide;
+        }) - nodes.begin());
+    };
 
-        int LoopNum = state.dataPlnt->PlantCallingOrderInfo(HalfLoopNum).LoopIndex;
-        LoopSideNum = state.dataPlnt->PlantCallingOrderInfo(HalfLoopNum).LoopSide;
+    std::vector<std::vector<int>> successors(nodes.size());
+    std::vector<int> indegree(nodes.size(), 0);
+    auto addDependency = [&](int before, int after) {
+        auto &successorList = successors[before];
+        if (std::find(successorList.begin(), successorList.end(), after) == successorList.end()) {
+            successorList.push_back(after);
+            ++indegree[after];
+        }
+    };
 
-        if (allocated(state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected)) {
-            for (ConnctNum = 1; ConnctNum <= isize(state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected); ++ConnctNum) {
-                int OtherLoopNum = state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected(ConnctNum).LoopNum;
-                OtherLoopSideNum = state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected(ConnctNum).LoopSideNum;
-                state.dataPlantMgr->OtherLoopCallingIndex = FindLoopSideInCallingOrder(state, OtherLoopNum, OtherLoopSideNum);
-
-                thisLoopPutsDemandOnAnother = state.dataPlnt->PlantLoop(LoopNum).LoopSide(LoopSideNum).Connected(ConnctNum).LoopDemandsOnRemote;
-                if (thisLoopPutsDemandOnAnother) {                                 // make sure this loop side is called before the other loop side
-                    if (state.dataPlantMgr->OtherLoopCallingIndex < HalfLoopNum) { // rearrange
-                        state.dataPlantMgr->newCallingIndex = min(HalfLoopNum + 1, state.dataPlnt->TotNumHalfLoops);
-                        ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
-                    }
-
-                } else {                                                           // make sure the other is called before this one
-                    if (state.dataPlantMgr->OtherLoopCallingIndex > HalfLoopNum) { // rearrange
-                        state.dataPlantMgr->newCallingIndex = max(HalfLoopNum, 1);
-
-                        if (OtherLoopSideNum == LoopSideLocation::Supply) { // if this is a supply side, don't push it before its own demand side
-                            state.dataPlantMgr->OtherLoopDemandSideCallingIndex =
-                                FindLoopSideInCallingOrder(state, OtherLoopNum, LoopSideLocation::Demand);
-                            if (state.dataPlantMgr->OtherLoopDemandSideCallingIndex < HalfLoopNum) { // good to go
-                                state.dataPlantMgr->newCallingIndex = min(state.dataPlantMgr->OtherLoopDemandSideCallingIndex + 1,
-                                                                          state.dataPlnt->TotNumHalfLoops); // put it right after its demand side
-                                ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
-                            } else { // move both sides of other loop before this, keeping demand side in front
-                                state.dataPlantMgr->NewOtherDemandSideCallingIndex = max(HalfLoopNum, 1);
-                                ShiftPlantLoopSideCallingOrder(
-                                    state, state.dataPlantMgr->OtherLoopDemandSideCallingIndex, state.dataPlantMgr->NewOtherDemandSideCallingIndex);
-                                // get fresh pointer after it has changed in previous call
-                                state.dataPlantMgr->OtherLoopCallingIndex = FindLoopSideInCallingOrder(state, OtherLoopNum, OtherLoopSideNum);
-                                state.dataPlantMgr->newCallingIndex = state.dataPlantMgr->NewOtherDemandSideCallingIndex + 1;
-                                ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
-                            }
-                        } else {
-                            ShiftPlantLoopSideCallingOrder(state, state.dataPlantMgr->OtherLoopCallingIndex, state.dataPlantMgr->newCallingIndex);
-                        }
-                    }
+    for (int loopNum = 1; loopNum <= state.dataPlnt->TotNumLoops; ++loopNum) {
+        addDependency(findNode(loopNum, LoopSideLocation::Demand), findNode(loopNum, LoopSideLocation::Supply));
+        for (auto loopSide : {LoopSideLocation::Demand, LoopSideLocation::Supply}) {
+            auto const &connections = state.dataPlnt->PlantLoop(loopNum).LoopSide(loopSide).Connected;
+            if (!allocated(connections)) continue;
+            for (int connectionNum = 1; connectionNum <= isize(connections); ++connectionNum) {
+                auto const &connection = connections(connectionNum);
+                int currentNode = findNode(loopNum, loopSide);
+                int remoteNode = findNode(connection.LoopNum, connection.LoopSideNum);
+                if (connection.LoopDemandsOnRemote) {
+                    addDependency(currentNode, remoteNode);
+                } else {
+                    addDependency(remoteNode, currentNode);
                 }
             }
         }
+    }
+
+    std::vector<int> ready;
+    for (int node = 0; node < static_cast<int>(nodes.size()); ++node) {
+        if (indegree[node] == 0) ready.push_back(node);
+    }
+
+    std::vector<int> revisedOrder;
+    revisedOrder.reserve(nodes.size());
+    while (!ready.empty()) {
+        std::sort(ready.begin(), ready.end(), nodeLess);
+        int node = ready.front();
+        ready.erase(ready.begin());
+        revisedOrder.push_back(node);
+        for (int successor : successors[node]) {
+            if (--indegree[successor] == 0) ready.push_back(successor);
+        }
+    }
+
+    if (revisedOrder.size() != nodes.size()) {
+        ShowWarningError(state, "PlantManager: plant loop calling-order dependencies contain a cycle; using canonical order for unresolved loop sides.");
+        std::vector<int> unresolved;
+        for (int node = 0; node < static_cast<int>(nodes.size()); ++node) {
+            if (std::find(revisedOrder.begin(), revisedOrder.end(), node) == revisedOrder.end()) unresolved.push_back(node);
+        }
+        std::sort(unresolved.begin(), unresolved.end(), nodeLess);
+        revisedOrder.insert(revisedOrder.end(), unresolved.begin(), unresolved.end());
+    }
+
+    for (int order = 0; order < static_cast<int>(revisedOrder.size()); ++order) {
+        auto const &node = nodes[revisedOrder[order]];
+        state.dataPlnt->PlantCallingOrderInfo(order + 1).LoopIndex = node.loopNum;
+        state.dataPlnt->PlantCallingOrderInfo(order + 1).LoopSide = node.loopSide;
     }
 }
 
@@ -3685,7 +3726,7 @@ int FindLoopSideInCallingOrder(EnergyPlusData &state, int const LoopNum, const L
     //       AUTHOR         B. Griffith
     //       DATE WRITTEN   April 2011
     //       MODIFIED       na
-    //       RE-ENGINEERED  na
+    //       RE-ENGINEERED  Sept. 2026 Joe Robertson
 
     // PURPOSE OF THIS FUNCTION:
     // locate loop and loop side in calling order structure

--- a/src/EnergyPlus/Plant/PlantManager.cc
+++ b/src/EnergyPlus/Plant/PlantManager.cc
@@ -3646,15 +3646,19 @@ void RevisePlantCallingOrder(EnergyPlusData &state)
         auto const &rhsNode = nodes[rhs];
         auto const &lhsName = state.dataPlnt->PlantLoop(lhsNode.loopNum).Name;
         auto const &rhsName = state.dataPlnt->PlantLoop(rhsNode.loopNum).Name;
-        if (lhsName != rhsName) return lhsName < rhsName;
-        if (lhsNode.loopSide != rhsNode.loopSide) return lhsNode.loopSide == LoopSideLocation::Demand;
+        if (lhsName != rhsName) {
+            return lhsName < rhsName;
+        }
+        if (lhsNode.loopSide != rhsNode.loopSide) {
+            return lhsNode.loopSide == LoopSideLocation::Demand;
+        }
         return lhsNode.loopNum < rhsNode.loopNum;
     };
 
     auto findNode = [&](int loopNum, DataPlant::LoopSideLocation loopSide) {
-        return static_cast<int>(std::find_if(nodes.begin(), nodes.end(), [&](auto const &node) {
-            return node.loopNum == loopNum && node.loopSide == loopSide;
-        }) - nodes.begin());
+        return static_cast<int>(
+            std::find_if(nodes.begin(), nodes.end(), [&](auto const &node) { return node.loopNum == loopNum && node.loopSide == loopSide; }) -
+            nodes.begin());
     };
 
     std::vector<std::vector<int>> successors(nodes.size());
@@ -3671,7 +3675,9 @@ void RevisePlantCallingOrder(EnergyPlusData &state)
         addDependency(findNode(loopNum, LoopSideLocation::Demand), findNode(loopNum, LoopSideLocation::Supply));
         for (auto loopSide : {LoopSideLocation::Demand, LoopSideLocation::Supply}) {
             auto const &connections = state.dataPlnt->PlantLoop(loopNum).LoopSide(loopSide).Connected;
-            if (!allocated(connections)) continue;
+            if (!allocated(connections)) {
+                continue;
+            }
             for (int connectionNum = 1; connectionNum <= isize(connections); ++connectionNum) {
                 auto const &connection = connections(connectionNum);
                 int currentNode = findNode(loopNum, loopSide);
@@ -3687,7 +3693,9 @@ void RevisePlantCallingOrder(EnergyPlusData &state)
 
     std::vector<int> ready;
     for (int node = 0; node < static_cast<int>(nodes.size()); ++node) {
-        if (indegree[node] == 0) ready.push_back(node);
+        if (indegree[node] == 0) {
+            ready.push_back(node);
+        }
     }
 
     std::vector<int> revisedOrder;
@@ -3698,15 +3706,20 @@ void RevisePlantCallingOrder(EnergyPlusData &state)
         ready.erase(ready.begin());
         revisedOrder.push_back(node);
         for (int successor : successors[node]) {
-            if (--indegree[successor] == 0) ready.push_back(successor);
+            if (--indegree[successor] == 0) {
+                ready.push_back(successor);
+            }
         }
     }
 
     if (revisedOrder.size() != nodes.size()) {
-        ShowWarningError(state, "PlantManager: plant loop calling-order dependencies contain a cycle; using canonical order for unresolved loop sides.");
+        ShowWarningError(state,
+                         "PlantManager: plant loop calling-order dependencies contain a cycle; using canonical order for unresolved loop sides.");
         std::vector<int> unresolved;
         for (int node = 0; node < static_cast<int>(nodes.size()); ++node) {
-            if (std::find(revisedOrder.begin(), revisedOrder.end(), node) == revisedOrder.end()) unresolved.push_back(node);
+            if (std::find(revisedOrder.begin(), revisedOrder.end(), node) == revisedOrder.end()) {
+                unresolved.push_back(node);
+            }
         }
         std::sort(unresolved.begin(), unresolved.end(), nodeLess);
         revisedOrder.insert(revisedOrder.end(), unresolved.begin(), unresolved.end());
@@ -3726,7 +3739,7 @@ int FindLoopSideInCallingOrder(EnergyPlusData &state, int const LoopNum, const L
     //       AUTHOR         B. Griffith
     //       DATE WRITTEN   April 2011
     //       MODIFIED       na
-    //       RE-ENGINEERED  Sept. 2026 Joe Robertson
+    //       RE-ENGINEERED  na
 
     // PURPOSE OF THIS FUNCTION:
     // locate loop and loop side in calling order structure

--- a/tst/EnergyPlus/unit/PlantHeatExchangerFluidToFluid.unit.cc
+++ b/tst/EnergyPlus/unit/PlantHeatExchangerFluidToFluid.unit.cc
@@ -2472,6 +2472,38 @@ TEST_F(EnergyPlusFixture, PlantHXControlWithFirstHVACIteration)
     EXPECT_NEAR(state->dataSize->CompDesWaterFlow(2).DesVolFlowRate, supSizData.DesVolFlowRate / 0.75, 0.00001); // HX Dem side registered flow rate
 }
 
+TEST_F(EnergyPlusFixture, PlantHXCalculateReadsCurrentNodeTemperatures)
+{
+    // Verify that each calculation reads the current inlet node temperatures and updates both outlet nodes.
+    state->init_state(*state);
+    state->dataLoopNodes->Node.allocate(4);
+    state->dataPlnt->PlantLoop.allocate(2);
+
+    state->dataPlantHXFluidToFluid->FluidHX.allocate(1);
+    auto &fluidHX = state->dataPlantHXFluidToFluid->FluidHX(1);
+    fluidHX.HeatExchangeModelType = PlantHeatExchangerFluidToFluid::FluidHXType::Ideal;
+    fluidHX.SupplySideLoop.inletNodeNum = 1;
+    fluidHX.SupplySideLoop.outletNodeNum = 3;
+    fluidHX.DemandSideLoop.inletNodeNum = 2;
+    fluidHX.DemandSideLoop.outletNodeNum = 4;
+    fluidHX.SupplySideLoop.loop = &state->dataPlnt->PlantLoop(1);
+    fluidHX.DemandSideLoop.loop = &state->dataPlnt->PlantLoop(2);
+    fluidHX.SupplySideLoop.loop->glycol = Fluid::GetWater(*state);
+    fluidHX.DemandSideLoop.loop->glycol = Fluid::GetWater(*state);
+
+    state->dataLoopNodes->Node(1).Temp = 20.0;
+    state->dataLoopNodes->Node(2).Temp = 10.0;
+    fluidHX.calculate(*state, 1.0, 1.0);
+    EXPECT_NEAR(state->dataLoopNodes->Node(3).Temp, 10.0, 0.05);
+    EXPECT_NEAR(state->dataLoopNodes->Node(4).Temp, 20.0, 0.05);
+
+    state->dataLoopNodes->Node(1).Temp = 18.0;
+    state->dataLoopNodes->Node(2).Temp = 12.0;
+    fluidHX.calculate(*state, 1.0, 1.0);
+    EXPECT_NEAR(state->dataLoopNodes->Node(3).Temp, 12.0, 0.05);
+    EXPECT_NEAR(state->dataLoopNodes->Node(4).Temp, 18.0, 0.05);
+}
+
 TEST_F(EnergyPlusFixture, PlantHXControl_CoolingSetpointOnOffWithComponentOverride)
 {
     // this unit test is for issue #5626.  Fixed logic for CoolingSetpointOnOffWithComponentOverride.

--- a/tst/EnergyPlus/unit/PlantManager.unit.cc
+++ b/tst/EnergyPlus/unit/PlantManager.unit.cc
@@ -269,6 +269,33 @@ namespace PlantManager {
         compare_eio_stream_substring(condenser_eio_output, true);
     }
 
+    TEST_F(EnergyPlusFixture, PlantManager_SizingPlantOrderMatchesPlantLoopNames)
+    {
+        // Verify that PlantLoop objects find their matching Sizing:Plant records by name, even when the records are listed in reverse order.
+        state->init_state(*state);
+
+        state->dataPlnt->PlantLoop.allocate(2);
+        state->dataPlnt->PlantLoop(1).Name = "Loop A";
+        state->dataPlnt->PlantLoop(2).Name = "Loop B";
+
+        state->dataSize->NumPltSizInput = 2;
+        state->dataSize->PlantSizData.allocate(2);
+        state->dataSize->PlantSizData(1).PlantLoopName = "Loop B";
+        state->dataSize->PlantSizData(1).ExitTemp = 7.0;
+        state->dataSize->PlantSizData(2).PlantLoopName = "Loop A";
+        state->dataSize->PlantSizData(2).ExitTemp = 29.4;
+
+        InitOneTimePlantSizingInfo(*state, 1);
+        InitOneTimePlantSizingInfo(*state, 2);
+
+        EXPECT_EQ(state->dataPlnt->PlantLoop(1).PlantSizNum, 2);
+        EXPECT_EQ(state->dataPlnt->PlantLoop(2).PlantSizNum, 1);
+        EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(1).PlantSizNum).PlantLoopName,
+                  state->dataPlnt->PlantLoop(1).Name);
+        EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(2).PlantSizNum).PlantLoopName,
+                  state->dataPlnt->PlantLoop(2).Name);
+    }
+
     TEST_F(EnergyPlusFixture, PlantManager_CheckPlantEquipmentCtrlType)
     {
         // Check size and alignment of DataPlant::PlantEquipmentCtrlType

--- a/tst/EnergyPlus/unit/PlantManager.unit.cc
+++ b/tst/EnergyPlus/unit/PlantManager.unit.cc
@@ -290,10 +290,8 @@ namespace PlantManager {
 
         EXPECT_EQ(state->dataPlnt->PlantLoop(1).PlantSizNum, 2);
         EXPECT_EQ(state->dataPlnt->PlantLoop(2).PlantSizNum, 1);
-        EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(1).PlantSizNum).PlantLoopName,
-                  state->dataPlnt->PlantLoop(1).Name);
-        EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(2).PlantSizNum).PlantLoopName,
-                  state->dataPlnt->PlantLoop(2).Name);
+        EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(1).PlantSizNum).PlantLoopName, state->dataPlnt->PlantLoop(1).Name);
+        EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(2).PlantSizNum).PlantLoopName, state->dataPlnt->PlantLoop(2).Name);
     }
 
     TEST_F(EnergyPlusFixture, PlantManager_CheckPlantEquipmentCtrlType)

--- a/tst/EnergyPlus/unit/PlantManager.unit.cc
+++ b/tst/EnergyPlus/unit/PlantManager.unit.cc
@@ -294,6 +294,33 @@ namespace PlantManager {
         EXPECT_EQ(state->dataSize->PlantSizData(state->dataPlnt->PlantLoop(2).PlantSizNum).PlantLoopName, state->dataPlnt->PlantLoop(2).Name);
     }
 
+    TEST_F(EnergyPlusFixture, PlantManager_RevisePlantCallingOrderKeepsDemandBeforeSupply)
+    {
+        state->init_state(*state);
+        state->dataPlnt->TotNumLoops = 3;
+        state->dataPlnt->TotNumHalfLoops = 6;
+        state->dataPlnt->PlantLoop.allocate(3);
+        state->dataPlnt->PlantCallingOrderInfo.allocate(6);
+
+        auto setOrder = [&](int order, int loopNum, LoopSideLocation loopSide) {
+            state->dataPlnt->PlantCallingOrderInfo(order).LoopIndex = loopNum;
+            state->dataPlnt->PlantCallingOrderInfo(order).LoopSide = loopSide;
+        };
+        setOrder(1, 1, LoopSideLocation::Supply);
+        setOrder(2, 2, LoopSideLocation::Demand);
+        setOrder(3, 1, LoopSideLocation::Demand);
+        setOrder(4, 2, LoopSideLocation::Supply);
+        setOrder(5, 3, LoopSideLocation::Supply);
+        setOrder(6, 3, LoopSideLocation::Demand);
+
+        RevisePlantCallingOrder(*state);
+
+        for (int loopNum = 1; loopNum <= state->dataPlnt->TotNumLoops; ++loopNum) {
+            EXPECT_LT(FindLoopSideInCallingOrder(*state, loopNum, LoopSideLocation::Demand),
+                      FindLoopSideInCallingOrder(*state, loopNum, LoopSideLocation::Supply));
+        }
+    }
+
     TEST_F(EnergyPlusFixture, PlantManager_CheckPlantEquipmentCtrlType)
     {
         // Check size and alignment of DataPlant::PlantEquipmentCtrlType


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #10573

### Description of the purpose of this PR

Ensure `RevisePlantCallingOrder` preserves demand-before-supply after rearranging interconnected loops. This prevents stale supply dispatch and removes results dependence on IDF plant-loop order. Added unit tests covering reordered `Sizing:Plant` records, repeated fluid-to-fluid heat exchanger calculations, and demand-before-supply calling order.

The following were noted in #10573 as possible culprits:
* `Minimum Plant Iterations`: See [comment below](https://github.com/NatLabRockies/EnergyPlus/pull/11791#issuecomment-5641740185).
* `HeatExchanger:FluidToFluid`: The HX unit test confirmed it rereads current inlet nodes and updates both outlet nodes correctly, so there is no simple stale-node pass-through defect in the HX itself.
* `Sizing:Plant`: Reversing the Sizing:Plant records still matched them to the correct PlantLoop objects by name, and fixed sizing order did not eliminate the pre-fix result differences. This disproves sizing-record order as the cause.
* `CoolingTower:VariableSpeed:Merkel`: Replacing CoolTools with the Merkel model still produced different Case1/2/3 results before the fix, while all three matched after canonical plant ordering. This argues against CoolTools being the root cause.

Tower model | State | Case1 site energy | Case2 site energy | Case3 site energy | Warning counts
-- | -- | -- | -- | -- | --
CoolTools | Before fix | 5810.29 GJ | 5713.14 GJ | 5810.85 GJ | 45,579 / 43,731 / 45,579
Merkel | Before fix | 5810.26 GJ | 5707.85 GJ | 5811.13 GJ | 160 / 155 / 157

### Pull Request Author

<!-- Add to this list or remove from it as applicable.  This is a simple templated set of guidelines. -->

 - [ ] Title of PR should be user-synopsis style (clearly understandable in a standalone changelog context)
 - [ ] Label the PR with at least one of: Defect, Refactoring, NewFeature, Performance, and/or DoNoPublish
 - [ ] Pull requests that impact EnergyPlus code must also include unit tests to cover enhancement or defect repair
 - [ ] Author should provide a "walkthrough" of relevant code changes using a GitHub code review comment process
 - [ ] If any diffs are expected, author must demonstrate they are justified using plots and descriptions
 - [ ] If changes fix a defect, the fix should be demonstrated in plots and descriptions
 - [ ] If any defect files are updated to a more recent version, upload new versions here or on DevSupport
 - [ ] If IDD requires transition, transition source, rules, ExpandObjects, and IDFs must be updated, and add IDDChange label
 - [ ] If structural output changes, add to output rules file and add OutputChange label
 - [ ] If adding/removing any LaTeX docs or figures, update that document's CMakeLists file dependencies
 - [ ] If adding/removing any output files (e.g., eplustbl.*)
   - [ ] Update ..\scripts\Epl-run.bat
   - [ ] Update ..\scripts\RunEPlus.bat
   - [ ] Update ..\src\EPLaunch\ MainModule.bas, epl-ui.frm, and epl.vbp (VersionComments)
   - [ ] Update ..\.github\workflows\energyplus.py

### Reviewer

<!-- This will not be exhaustively relevant to every PR. -->

 - [ ] Perform a Code Review on GitHub
 - [ ] If branch is behind develop, merge develop and build locally to check for side effects of the merge
 - [ ] If defect, verify by running develop branch and reproducing defect, then running PR and reproducing fix
 - [ ] If feature, test running new feature, try creative ways to break it
 - [ ] CI status: all green or justified
 - [ ] Check that performance is not impacted (CI Linux results include performance check)
 - [ ] Run Unit Test(s) locally
 - [ ] Check any new function arguments for performance impacts
 - [ ] Verify IDF naming conventions and styles, memos and notes and defaults
 - [ ] If new idf included, locally check the err file and other outputs
